### PR TITLE
UI Tweaks and Enhancements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,9 +92,13 @@ function AppContent({ isMobile }: { isMobile: boolean }) {
             selectedTypes={appState.filters.selectedTypes}
             selectedStatuses={appState.filters.selectedStatuses}
             searchTerm={appState.filters.searchTerm}
+            destructionDateStart={appState.filters.destructionDateStart}
+            destructionDateEnd={appState.filters.destructionDateEnd}
             setSelectedTypes={appState.setSelectedTypes}
             setSelectedStatuses={appState.setSelectedStatuses}
             setSearchTerm={appState.setSearchTerm}
+            setDestructionDateStart={appState.setDestructionDateStart}
+            setDestructionDateEnd={appState.setDestructionDateEnd}
             hasActiveFilters={appState.hasActiveFilters}
             clearAllFilters={appState.clearAllFilters}
             openFilterModal={appState.openFilterModal}
@@ -219,6 +223,7 @@ function AppContent({ isMobile }: { isMobile: boolean }) {
           onCreationYearStartChange={appState.setTempCreationYearStart}
           onCreationYearEndChange={appState.setTempCreationYearEnd}
           onSearchChange={appState.setSearchTerm}
+          sites={mockSites}
         />
         <div className="mt-6 flex justify-end gap-3">
           <button

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -239,6 +239,8 @@ function AppContent({ isMobile }: { isMobile: boolean }) {
           <button
             onClick={appState.applyFilters}
             className={`px-4 py-2 text-white rounded-lg shadow-md hover:shadow-lg transition-all duration-200 font-semibold active:scale-95 ${
+              appState.hasUnappliedChanges ? "animate-pulse ring-2 ring-white/50" : ""
+            } ${
               isDark
                 ? "bg-[#2d5a38] hover:bg-[#244a2e]"
                 : "bg-[#009639] hover:bg-[#007b2f]"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -228,22 +228,30 @@ function AppContent({ isMobile }: { isMobile: boolean }) {
         <div className="mt-6 flex justify-end gap-3">
           <button
             onClick={appState.clearTempFilters}
-            className={`px-4 py-2 rounded-lg transition-colors duration-200 font-medium ${
-              isDark
-                ? "text-gray-300 hover:bg-gray-700"
-                : "text-gray-600 hover:bg-gray-100"
+            disabled={!appState.hasTempFilters}
+            className={`px-4 py-2 rounded-lg transition-colors duration-200 font-medium border border-[#000000] ${
+              !appState.hasTempFilters
+                ? "bg-gray-300 text-gray-500 cursor-not-allowed"
+                : isDark
+                  ? "text-gray-300 hover:bg-gray-700"
+                  : "text-gray-600 hover:bg-gray-100"
             }`}
           >
             Clear All
           </button>
           <button
             onClick={appState.applyFilters}
-            className={`px-4 py-2 text-white rounded-lg shadow-md hover:shadow-lg transition-all duration-200 font-semibold active:scale-95 ${
-              appState.hasUnappliedChanges ? "animate-pulse ring-2 ring-white/50" : ""
-            } ${
-              isDark
-                ? "bg-[#2d5a38] hover:bg-[#244a2e]"
-                : "bg-[#009639] hover:bg-[#007b2f]"
+            disabled={!appState.hasUnappliedChanges}
+            className={`px-4 py-2 rounded-lg transition-all duration-200 font-semibold border border-[#000000] ${
+              !appState.hasUnappliedChanges
+                ? "bg-gray-300 text-gray-500 cursor-not-allowed shadow-none"
+                : `text-white shadow-md hover:shadow-lg active:scale-95 ${
+                    appState.hasUnappliedChanges ? "animate-pulse ring-2 ring-white/50" : ""
+                  } ${
+                    isDark
+                      ? "bg-[#2d5a38] hover:bg-[#244a2e]"
+                      : "bg-[#009639] hover:bg-[#007b2f]"
+                  }`
             }`}
           >
             Apply Filters

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,7 +137,7 @@ function AppContent({ isMobile }: { isMobile: boolean }) {
         onClose={() => appState.setIsTableExpanded(false)}
         zIndex={9999}
       >
-        <div className="max-h-[80vh] overflow-auto">
+        <div className="h-[80vh]">
           <SitesTable
             sites={filteredSites}
             onSiteClick={appState.setSelectedSite}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -205,46 +205,42 @@ function AppContent({ isMobile }: { isMobile: boolean }) {
         onClose={() => appState.setIsFilterOpen(false)}
         zIndex={10001}
       >
-        <div className={`rounded-xl p-6 max-w-5xl shadow-2xl transition-colors duration-200 ${
-          isDark ? "bg-gray-800" : "bg-white"
-        }`}>
-          <h2 className={`text-2xl font-bold mb-6 ${isDark ? "text-gray-100" : "text-gray-900"}`}>Filter Sites</h2>
-          <FilterBar
-            selectedTypes={appState.tempFilters.tempSelectedTypes}
-            selectedStatuses={appState.tempFilters.tempSelectedStatuses}
-            destructionDateStart={appState.tempFilters.tempDestructionDateStart}
-            destructionDateEnd={appState.tempFilters.tempDestructionDateEnd}
-            searchTerm={appState.filters.searchTerm}
-            onTypeChange={appState.setTempSelectedTypes}
-            onStatusChange={appState.setTempSelectedStatuses}
-            onDestructionDateStartChange={appState.setTempDestructionDateStart}
-            onDestructionDateEndChange={appState.setTempDestructionDateEnd}
-            onCreationYearStartChange={appState.setTempCreationYearStart}
-            onCreationYearEndChange={appState.setTempCreationYearEnd}
-            onSearchChange={appState.setSearchTerm}
-          />
-          <div className="mt-6 flex justify-end gap-3">
-            <button
-              onClick={appState.clearTempFilters}
-              className={`px-4 py-2 rounded-lg transition-colors duration-200 font-medium ${
-                isDark
-                  ? "text-gray-300 hover:bg-gray-700"
-                  : "text-gray-600 hover:bg-gray-100"
-              }`}
-            >
-              Clear All
-            </button>
-            <button
-              onClick={appState.applyFilters}
-              className={`px-4 py-2 text-white rounded-lg shadow-md hover:shadow-lg transition-all duration-200 font-semibold active:scale-95 ${
-                isDark
-                  ? "bg-[#2d5a38] hover:bg-[#244a2e]"
-                  : "bg-[#009639] hover:bg-[#007b2f]"
-              }`}
-            >
-              Apply Filters
-            </button>
-          </div>
+        <h2 className={`text-2xl font-bold mb-6 ${isDark ? "text-gray-100" : "text-gray-900"}`}>Filter Sites</h2>
+        <FilterBar
+          selectedTypes={appState.tempFilters.tempSelectedTypes}
+          selectedStatuses={appState.tempFilters.tempSelectedStatuses}
+          destructionDateStart={appState.tempFilters.tempDestructionDateStart}
+          destructionDateEnd={appState.tempFilters.tempDestructionDateEnd}
+          searchTerm={appState.filters.searchTerm}
+          onTypeChange={appState.setTempSelectedTypes}
+          onStatusChange={appState.setTempSelectedStatuses}
+          onDestructionDateStartChange={appState.setTempDestructionDateStart}
+          onDestructionDateEndChange={appState.setTempDestructionDateEnd}
+          onCreationYearStartChange={appState.setTempCreationYearStart}
+          onCreationYearEndChange={appState.setTempCreationYearEnd}
+          onSearchChange={appState.setSearchTerm}
+        />
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            onClick={appState.clearTempFilters}
+            className={`px-4 py-2 rounded-lg transition-colors duration-200 font-medium ${
+              isDark
+                ? "text-gray-300 hover:bg-gray-700"
+                : "text-gray-600 hover:bg-gray-100"
+            }`}
+          >
+            Clear All
+          </button>
+          <button
+            onClick={appState.applyFilters}
+            className={`px-4 py-2 text-white rounded-lg shadow-md hover:shadow-lg transition-all duration-200 font-semibold active:scale-95 ${
+              isDark
+                ? "bg-[#2d5a38] hover:bg-[#244a2e]"
+                : "bg-[#009639] hover:bg-[#007b2f]"
+            }`}
+          >
+            Apply Filters
+          </button>
         </div>
       </Modal>
 

--- a/src/__tests__/darkMode.test.tsx
+++ b/src/__tests__/darkMode.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
 import { ThemeProvider } from "../contexts/ThemeContext";
 import { CalendarProvider } from "../contexts/CalendarContext";
 import { AnimationProvider } from "../contexts/AnimationContext";
@@ -50,9 +50,14 @@ describe("Dark Mode - Component Rendering", () => {
   const testSite = mockSites[0];
   const noop = () => {};
 
-  // Clean up localStorage before each test to prevent cross-test pollution
+  // Clean up localStorage and DOM before each test to prevent cross-test pollution
   beforeEach(() => {
     localStorage.clear();
+  });
+
+  // Clean up DOM after each test
+  afterEach(() => {
+    cleanup();
   });
 
   describe("About Modal", () => {

--- a/src/components/FilterBar/DateRangeFilter.tsx
+++ b/src/components/FilterBar/DateRangeFilter.tsx
@@ -9,11 +9,14 @@ interface DateRangeFilterProps {
   onEndChange: (date: Date | null) => void;
   label: string;
   tooltip?: string;
+  defaultStartDate?: Date;
+  defaultEndDate?: Date;
 }
 
 /**
  * DateRangeFilter - Reusable date range picker with optional tooltip
  * Handles date input validation and formatting
+ * Shows default values when startDate/endDate are null
  */
 export function DateRangeFilter({
   startDate,
@@ -22,6 +25,8 @@ export function DateRangeFilter({
   onEndChange,
   label,
   tooltip = "Date filters use Gregorian calendar only",
+  defaultStartDate,
+  defaultEndDate,
 }: DateRangeFilterProps) {
   const t = useThemeClasses();
 
@@ -44,7 +49,7 @@ export function DateRangeFilter({
       <div className="flex items-center gap-2">
         <Input
           variant="date"
-          value={startDate ? startDate.toISOString().split("T")[0] : ""}
+          value={(startDate || defaultStartDate)?.toISOString().split("T")[0] || ""}
           onChange={(e) => {
             onStartChange(e.target.value ? new Date(e.target.value) : null);
           }}
@@ -54,7 +59,7 @@ export function DateRangeFilter({
         <span className={`text-sm font-medium ${t.text.body}`}>to</span>
         <Input
           variant="date"
-          value={endDate ? endDate.toISOString().split("T")[0] : ""}
+          value={(endDate || defaultEndDate)?.toISOString().split("T")[0] || ""}
           onChange={(e) => {
             onEndChange(e.target.value ? new Date(e.target.value) : null);
           }}

--- a/src/components/FilterBar/FilterBar.test.tsx
+++ b/src/components/FilterBar/FilterBar.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
-import { renderWithTheme } from "../../test-utils/renderWithTheme";
+import { renderWithTheme, screen } from "../../test-utils/renderWithTheme";
 import { FilterBar } from "./FilterBar";
 import { CalendarProvider } from "../../contexts/CalendarContext";
+import type { GazaSite } from "../../types";
 
 describe("FilterBar", () => {
   const mockProps = {
@@ -38,5 +39,164 @@ describe("FilterBar", () => {
     );
     const bodyText = document.body.textContent || "";
     expect(bodyText.length).toBeGreaterThan(20);
+  });
+
+  describe("Default Date Values", () => {
+    const mockSites: GazaSite[] = [
+      {
+        id: "1",
+        name: "Ancient Mosque",
+        type: "mosque",
+        yearBuilt: "800 BCE",
+        coordinates: [31.5, 34.5],
+        status: "destroyed",
+        dateDestroyed: "2023-10-15",
+        description: "Test site",
+        historicalSignificance: "High",
+        culturalValue: "High",
+        sources: [],
+        verifiedBy: [],
+      },
+      {
+        id: "2",
+        name: "Medieval Church",
+        type: "church",
+        yearBuilt: "12th century",
+        coordinates: [31.6, 34.6],
+        status: "damaged",
+        dateDestroyed: "2023-12-20",
+        description: "Test site",
+        historicalSignificance: "High",
+        culturalValue: "High",
+        sources: [],
+        verifiedBy: [],
+      },
+      {
+        id: "3",
+        name: "Modern Museum",
+        type: "museum",
+        yearBuilt: "1950",
+        coordinates: [31.7, 34.7],
+        status: "destroyed",
+        dateDestroyed: "2024-01-05",
+        description: "Test site",
+        historicalSignificance: "Medium",
+        culturalValue: "Medium",
+        sources: [],
+        verifiedBy: [],
+      },
+    ];
+
+    it("calculates destruction date range from sites data", () => {
+      renderWithTheme(
+        <CalendarProvider>
+          <FilterBar {...mockProps} sites={mockSites} />
+        </CalendarProvider>
+      );
+
+      // Check that date inputs exist (they should show default values)
+      const dateInputs = screen.getAllByPlaceholderText(/From|To/);
+      expect(dateInputs.length).toBeGreaterThan(0);
+    });
+
+    it("calculates year built range from sites data", () => {
+      renderWithTheme(
+        <CalendarProvider>
+          <FilterBar {...mockProps} sites={mockSites} />
+        </CalendarProvider>
+      );
+
+      // Year Built label should be visible (using getAllByText since it appears in multiple places)
+      const yearBuiltLabels = screen.getAllByText("Year Built");
+      expect(yearBuiltLabels.length).toBeGreaterThan(0);
+    });
+
+    it("handles empty sites array gracefully", () => {
+      const { container } = renderWithTheme(
+        <CalendarProvider>
+          <FilterBar {...mockProps} sites={[]} />
+        </CalendarProvider>
+      );
+      expect(container).toBeInTheDocument();
+    });
+
+    it("handles sites without destruction dates", () => {
+      const sitesWithoutDates: GazaSite[] = [
+        {
+          id: "1",
+          name: "Test Site",
+          type: "mosque",
+          yearBuilt: "1900",
+          coordinates: [31.5, 34.5],
+          status: "damaged",
+          description: "Test",
+          historicalSignificance: "High",
+          culturalValue: "High",
+          sources: [],
+          verifiedBy: [],
+        },
+      ];
+
+      const { container } = renderWithTheme(
+        <CalendarProvider>
+          <FilterBar {...mockProps} sites={sitesWithoutDates} />
+        </CalendarProvider>
+      );
+      expect(container).toBeInTheDocument();
+    });
+
+    it("handles sites with various year formats", () => {
+      const sitesWithVariousYears: GazaSite[] = [
+        {
+          id: "1",
+          name: "BCE Site",
+          type: "archaeological",
+          yearBuilt: "800 BCE",
+          coordinates: [31.5, 34.5],
+          status: "destroyed",
+          dateDestroyed: "2023-10-15",
+          description: "Test",
+          historicalSignificance: "High",
+          culturalValue: "High",
+          sources: [],
+          verifiedBy: [],
+        },
+        {
+          id: "2",
+          name: "Century Site",
+          type: "church",
+          yearBuilt: "7th century",
+          coordinates: [31.6, 34.6],
+          status: "damaged",
+          dateDestroyed: "2023-11-20",
+          description: "Test",
+          historicalSignificance: "High",
+          culturalValue: "High",
+          sources: [],
+          verifiedBy: [],
+        },
+        {
+          id: "3",
+          name: "Modern Site",
+          type: "museum",
+          yearBuilt: "2000",
+          coordinates: [31.7, 34.7],
+          status: "destroyed",
+          dateDestroyed: "2024-01-05",
+          description: "Test",
+          historicalSignificance: "Medium",
+          culturalValue: "Medium",
+          sources: [],
+          verifiedBy: [],
+        },
+      ];
+
+      const { container } = renderWithTheme(
+        <CalendarProvider>
+          <FilterBar {...mockProps} sites={sitesWithVariousYears} />
+        </CalendarProvider>
+      );
+      expect(container).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/FilterBar/FilterBar.tsx
+++ b/src/components/FilterBar/FilterBar.tsx
@@ -91,10 +91,11 @@ export function FilterBar({
       return year.toString();
     };
 
+    const defaultStartEra = minYear < 0 ? ("BCE" as const) : ("CE" as const);
     return {
       defaultStartYear: formatYear(minYear),
       defaultEndYear: formatYear(maxYear),
-      defaultStartEra: (minYear < 0 ? "BCE" : "CE") as const,
+      defaultStartEra,
     };
   }, [sites]);
 

--- a/src/components/FilterBar/YearRangeFilter.tsx
+++ b/src/components/FilterBar/YearRangeFilter.tsx
@@ -12,6 +12,7 @@ interface YearRangeFilterProps {
   supportBCE?: boolean;
   startYearDefault?: string;
   endYearDefault?: string;
+  startEraDefault?: "CE" | "BCE";
 }
 
 /**
@@ -27,12 +28,13 @@ export function YearRangeFilter({
   supportBCE = true,
   startYearDefault = "",
   endYearDefault = new Date().getFullYear().toString(),
+  startEraDefault = "CE",
 }: YearRangeFilterProps) {
   const t = useThemeClasses();
 
   // Local state for year input and era selection
   const [startYearInput, setStartYearInput] = React.useState(startYearDefault);
-  const [startYearEra, setStartYearEra] = React.useState<"CE" | "BCE">("CE");
+  const [startYearEra, setStartYearEra] = React.useState<"CE" | "BCE">(startEraDefault);
   const [endYearInput, setEndYearInput] = React.useState(endYearDefault);
   const [endYearEra, setEndYearEra] = React.useState<"CE" | "BCE">("CE");
 

--- a/src/components/Icons/SiteTypeIcon.tsx
+++ b/src/components/Icons/SiteTypeIcon.tsx
@@ -1,7 +1,8 @@
 import {
   BuildingLibraryIcon,
-  BuildingOffice2Icon,
-} from "@heroicons/react/24/outline";
+  MagnifyingGlassIcon,
+  HomeModernIcon,
+} from "@heroicons/react/24/solid";
 import type { GazaSite } from "../../types";
 
 interface SiteTypeIconProps {
@@ -10,8 +11,37 @@ interface SiteTypeIconProps {
 }
 
 /**
- * Professional SVG icon component for site types
- * Replaces emoji icons for consistent cross-browser rendering
+ * Unicode icon wrapper component for text-based symbols
+ */
+function UnicodeIcon({
+  symbol,
+  className,
+  ...props
+}: {
+  symbol: string;
+  className?: string;
+  "aria-label"?: string;
+  role?: string;
+}) {
+  return (
+    <span
+      className={className}
+      style={{
+        fontSize: '20px',
+        lineHeight: 1,
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+      {...props}
+    >
+      {symbol}
+    </span>
+  );
+}
+
+/**
+ * Icon component for site types with distinct symbols
  */
 export function SiteTypeIcon({
   type,
@@ -19,34 +49,36 @@ export function SiteTypeIcon({
 }: SiteTypeIconProps) {
   switch (type) {
     case "mosque":
-      // Using BuildingLibraryIcon for mosque (dome-like structure)
+      // Unicode Star and Crescent symbol (Islamic symbol)
       return (
-        <BuildingLibraryIcon
+        <UnicodeIcon
+          symbol="☪"
           className={className}
           aria-label="Mosque"
           role="img"
         />
       );
     case "church":
-      // Using BuildingLibraryIcon for church (religious building)
+      // Unicode Latin Cross symbol
       return (
-        <BuildingLibraryIcon
+        <UnicodeIcon
+          symbol="✝"
           className={className}
           aria-label="Church"
           role="img"
         />
       );
     case "archaeological":
-      // Using BuildingLibraryIcon for archaeological site (classical building)
+      // Magnifying glass (research/discovery)
       return (
-        <BuildingLibraryIcon
+        <MagnifyingGlassIcon
           className={className}
           aria-label="Archaeological site"
           role="img"
         />
       );
     case "museum":
-      // Using BuildingLibraryIcon for museum (institutional building)
+      // Classical building with columns
       return (
         <BuildingLibraryIcon
           className={className}
@@ -55,9 +87,9 @@ export function SiteTypeIcon({
         />
       );
     case "historic-building":
-      // Using HomeModernIcon for historic building
+      // Modern building icon (represents historic architecture)
       return (
-        <BuildingOffice2Icon
+        <HomeModernIcon
           className={className}
           aria-label="Historic building"
           role="img"

--- a/src/components/Layout/DesktopLayout.tsx
+++ b/src/components/Layout/DesktopLayout.tsx
@@ -128,7 +128,7 @@ export function DesktopLayout({
                     className="px-4 py-2 bg-[#009639] hover:bg-[#007b2f] text-white
                                rounded-lg shadow-md hover:shadow-lg
                                transition-all duration-200 font-semibold
-                               active:scale-95 text-sm"
+                               active:scale-95 text-sm border border-[#000000]"
                   >
                     Filters
                   </button>
@@ -172,7 +172,7 @@ export function DesktopLayout({
                       className="px-3 py-1.5 bg-[#ed3039] hover:bg-[#d4202a] text-white
                                  rounded-lg shadow-md hover:shadow-lg
                                  transition-all duration-200 font-semibold
-                                 active:scale-95 text-xs"
+                                 active:scale-95 text-xs border border-[#000000]"
                     >
                       Clear
                     </button>

--- a/src/components/Layout/DesktopLayout.tsx
+++ b/src/components/Layout/DesktopLayout.tsx
@@ -279,7 +279,7 @@ export function DesktopLayout({
           </div>
 
           {/* Timeline Scrubber - Fixed height at bottom */}
-          <div className="mt-3 flex-shrink-0 h-[200px] relative z-10">
+          <div className="mt-3 mb-4 flex-shrink-0 h-[200px] relative z-10">
             <Suspense fallback={<SkeletonMap />}>
               <TimelineScrubber
                 sites={filteredSites}

--- a/src/components/Layout/DesktopLayout.tsx
+++ b/src/components/Layout/DesktopLayout.tsx
@@ -24,9 +24,13 @@ interface DesktopLayoutProps {
   selectedTypes: Array<GazaSite["type"]>;
   selectedStatuses: Array<GazaSite["status"]>;
   searchTerm: string;
+  destructionDateStart: Date | null;
+  destructionDateEnd: Date | null;
   setSelectedTypes: (types: Array<GazaSite["type"]>) => void;
   setSelectedStatuses: (statuses: Array<GazaSite["status"]>) => void;
   setSearchTerm: (term: string) => void;
+  setDestructionDateStart: (date: Date | null) => void;
+  setDestructionDateEnd: (date: Date | null) => void;
   hasActiveFilters: boolean;
   clearAllFilters: () => void;
   openFilterModal: () => void;
@@ -54,9 +58,13 @@ export function DesktopLayout({
   selectedTypes,
   selectedStatuses,
   searchTerm,
+  destructionDateStart,
+  destructionDateEnd,
   setSelectedTypes,
   setSelectedStatuses,
   setSearchTerm,
+  setDestructionDateStart,
+  setDestructionDateEnd,
   hasActiveFilters,
   clearAllFilters,
   openFilterModal,
@@ -257,6 +265,10 @@ export function DesktopLayout({
               <TimelineScrubber
                 sites={filteredSites}
                 onSyncMapChange={setSyncMapToTimeline}
+                destructionDateStart={destructionDateStart}
+                destructionDateEnd={destructionDateEnd}
+                onDestructionDateStartChange={setDestructionDateStart}
+                onDestructionDateEndChange={setDestructionDateEnd}
               />
             </Suspense>
           </div>

--- a/src/components/Layout/DesktopLayout.tsx
+++ b/src/components/Layout/DesktopLayout.tsx
@@ -117,119 +117,138 @@ export function DesktopLayout({
         <div className="flex-1 min-w-0 pr-6 flex flex-col">
           {/* Filter bar - Horizontal component with compact padding */}
           <div className={`flex-shrink-0 mt-4 py-3 backdrop-blur-sm border-2 border-[#000000] rounded-lg shadow-xl relative z-[5] transition-colors duration-200 ${isDark ? "bg-[#000000]/95" : "bg-white/95"}`}>
-            <div className="flex items-start gap-4 px-3">
-              {/* Left side - Filter controls */}
-              <div className="flex-1 flex items-center gap-3 flex-wrap">
-                {/* Filter Button */}
-                <button
-                  onClick={openFilterModal}
-                  className="px-4 py-2 bg-[#009639] hover:bg-[#007b2f] text-white
-                             rounded-lg shadow-md hover:shadow-lg
-                             transition-all duration-200 font-semibold
-                             active:scale-95 text-sm"
-                >
-                  Filters
-                </button>
+            <div className="flex flex-col gap-2">
+              {/* Top row - Filter controls and legend */}
+              <div className="flex items-start gap-4 px-3">
+                {/* Left side - Filter controls */}
+                <div className="flex-1 flex items-center gap-3">
+                  {/* Filter Button */}
+                  <button
+                    onClick={openFilterModal}
+                    className="px-4 py-2 bg-[#009639] hover:bg-[#007b2f] text-white
+                               rounded-lg shadow-md hover:shadow-lg
+                               transition-all duration-200 font-semibold
+                               active:scale-95 text-sm"
+                  >
+                    Filters
+                  </button>
 
-                {/* Search bar - inline */}
-                <div className="relative flex-1 max-w-xs border border-[#000000] rounded-lg">
-                  <Input
-                    type="text"
-                    value={searchTerm}
-                    onChange={(e) => setSearchTerm(e.target.value)}
-                    placeholder="Search sites..."
-                    className="w-full pr-8 text-xs py-1 px-2 border-0"
-                  />
-                  {searchTerm.trim().length > 0 && (
-                    <button
-                      onClick={() => setSearchTerm("")}
-                      className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
-                      aria-label="Clear search"
-                    >
-                      <svg
-                        className="w-3 h-3"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
+                  {/* Search bar - inline */}
+                  <div className="relative flex-1 max-w-xs border border-[#000000] rounded-lg">
+                    <Input
+                      type="text"
+                      value={searchTerm}
+                      onChange={(e) => setSearchTerm(e.target.value)}
+                      placeholder="Search sites..."
+                      className="w-full pr-8 text-xs py-1 px-2 border-0"
+                    />
+                    {searchTerm.trim().length > 0 && (
+                      <button
+                        onClick={() => setSearchTerm("")}
+                        className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+                        aria-label="Clear search"
                       >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M6 18L18 6M6 6l12 12"
-                        />
-                      </svg>
+                        <svg
+                          className="w-3 h-3"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M6 18L18 6M6 6l12 12"
+                          />
+                        </svg>
+                      </button>
+                    )}
+                  </div>
+
+                  {/* Clear button */}
+                  {hasActiveFilters && (
+                    <button
+                      onClick={clearAllFilters}
+                      className="px-3 py-1.5 bg-[#ed3039] hover:bg-[#d4202a] text-white
+                                 rounded-lg shadow-md hover:shadow-lg
+                                 transition-all duration-200 font-semibold
+                                 active:scale-95 text-xs"
+                    >
+                      Clear
                     </button>
                   )}
                 </div>
 
-                {/* Active filter tags */}
-                {selectedTypes.map((type) => (
-                  <FilterTag
-                    key={type}
-                    label={formatLabel(type)}
-                    onRemove={() => setSelectedTypes(selectedTypes.filter((t) => t !== type))}
-                    ariaLabel={`Remove ${type} filter`}
-                  />
-                ))}
-                {selectedStatuses.map((status) => (
-                  <FilterTag
-                    key={status}
-                    label={formatLabel(status)}
-                    onRemove={() =>
-                      setSelectedStatuses(selectedStatuses.filter((s) => s !== status))
-                    }
-                    ariaLabel={`Remove ${status} filter`}
-                  />
-                ))}
+                {/* Right side - Status legend and site count */}
+                <div className="flex items-center gap-4">
+                  {/* Site count */}
+                  <span className={`text-xs font-medium whitespace-nowrap ${t.text.muted}`}>
+                    Showing {filteredSites.length} of {totalSites} sites
+                  </span>
 
-                {/* Clear button */}
-                {hasActiveFilters && (
-                  <button
-                    onClick={clearAllFilters}
-                    className="px-3 py-1.5 bg-[#ed3039] hover:bg-[#d4202a] text-white
-                               rounded-lg shadow-md hover:shadow-lg
-                               transition-all duration-200 font-semibold
-                               active:scale-95 text-xs"
-                  >
-                    Clear
-                  </button>
-                )}
-              </div>
-
-              {/* Right side - Status legend and site count */}
-              <div className="flex items-center gap-4">
-                {/* Site count */}
-                <span className={`text-xs font-medium whitespace-nowrap ${t.text.muted}`}>
-                  Showing {filteredSites.length} of {totalSites} sites
-                </span>
-
-                {/* Status Legend (Color Key) */}
-                <div className={`flex items-center gap-3 px-3 py-1.5 rounded-md border border-[#000000] ${t.bg.secondary}`}>
-                  <span className={`text-xs font-semibold ${t.text.body}`}>Color Key:</span>
-                  <div className="flex items-center gap-1.5">
-                    <div
-                      className="w-3 h-3 rounded-full border-2 border-white shadow-sm"
-                      style={{ backgroundColor: "#b91c1c" }}
-                    />
-                    <span className={`text-xs ${t.text.body}`}>Destroyed</span>
-                  </div>
-                  <div className="flex items-center gap-1.5">
-                    <div
-                      className="w-3 h-3 rounded-full border-2 border-white shadow-sm"
-                      style={{ backgroundColor: "#d97706" }}
-                    />
-                    <span className={`text-xs ${t.text.body}`}>Heavily Damaged</span>
-                  </div>
-                  <div className="flex items-center gap-1.5">
-                    <div
-                      className="w-3 h-3 rounded-full border-2 border-white shadow-sm"
-                      style={{ backgroundColor: "#ca8a04" }}
-                    />
-                    <span className={`text-xs ${t.text.body}`}>Damaged</span>
+                  {/* Status Legend (Color Key) */}
+                  <div className={`flex items-center gap-3 px-3 py-1.5 rounded-md border border-[#000000] ${t.bg.secondary}`}>
+                    <span className={`text-xs font-semibold ${t.text.body}`}>Color Key:</span>
+                    <div className="flex items-center gap-1.5">
+                      <div
+                        className="w-3 h-3 rounded-full border-2 border-white shadow-sm"
+                        style={{ backgroundColor: "#b91c1c" }}
+                      />
+                      <span className={`text-xs ${t.text.body}`}>Destroyed</span>
+                    </div>
+                    <div className="flex items-center gap-1.5">
+                      <div
+                        className="w-3 h-3 rounded-full border-2 border-white shadow-sm"
+                        style={{ backgroundColor: "#d97706" }}
+                      />
+                      <span className={`text-xs ${t.text.body}`}>Heavily Damaged</span>
+                    </div>
+                    <div className="flex items-center gap-1.5">
+                      <div
+                        className="w-3 h-3 rounded-full border-2 border-white shadow-sm"
+                        style={{ backgroundColor: "#ca8a04" }}
+                      />
+                      <span className={`text-xs ${t.text.body}`}>Damaged</span>
+                    </div>
                   </div>
                 </div>
               </div>
+
+              {/* Bottom row - Active filter tags */}
+              {hasActiveFilters && (
+                <div className="flex items-center gap-2 px-3 flex-wrap">
+                  {selectedTypes.map((type) => (
+                    <FilterTag
+                      key={type}
+                      label={formatLabel(type)}
+                      onRemove={() => setSelectedTypes(selectedTypes.filter((t) => t !== type))}
+                      ariaLabel={`Remove ${type} filter`}
+                    />
+                  ))}
+                  {selectedStatuses.map((status) => (
+                    <FilterTag
+                      key={status}
+                      label={formatLabel(status)}
+                      onRemove={() =>
+                        setSelectedStatuses(selectedStatuses.filter((s) => s !== status))
+                      }
+                      ariaLabel={`Remove ${status} filter`}
+                    />
+                  ))}
+                  {/* Destruction date filter tag */}
+                  {(destructionDateStart || destructionDateEnd) && (
+                    <FilterTag
+                      key="destruction-date"
+                      label={`Date Range: ${destructionDateStart?.toLocaleDateString() || '...'} - ${destructionDateEnd?.toLocaleDateString() || '...'}`}
+                      onRemove={() => {
+                        setDestructionDateStart(null);
+                        setDestructionDateEnd(null);
+                      }}
+                      ariaLabel="Remove destruction date filter"
+                    />
+                  )}
+                </div>
+              )}
             </div>
           </div>
 

--- a/src/components/Layout/DesktopLayout.tsx
+++ b/src/components/Layout/DesktopLayout.tsx
@@ -255,7 +255,7 @@ export function DesktopLayout({
           {/* Two maps side by side - Constrained height to leave room for timeline */}
           <div className="flex gap-4 min-h-0 pt-3" style={{ height: 'calc(100% - 270px)' }}>
             {/* Center - Heritage Map (Traditional/Satellite toggle) */}
-            <div className="flex-1 min-w-0 h-full border-4 border-[#000000] rounded-lg shadow-xl overflow-hidden relative z-10">
+            <div className="flex-1 min-w-0 h-full border-2 border-[#000000] rounded-lg shadow-xl overflow-hidden relative z-10">
               <Suspense fallback={<SkeletonMap />}>
                 <HeritageMap
                   sites={filteredSites}
@@ -267,7 +267,7 @@ export function DesktopLayout({
             </div>
 
             {/* Right - Site Detail View (Satellite only, zooms on selection) */}
-            <div className="flex-1 min-w-0 h-full border-4 border-[#000000] rounded-lg shadow-xl overflow-hidden relative z-10">
+            <div className="flex-1 min-w-0 h-full border-2 border-[#000000] rounded-lg shadow-xl overflow-hidden relative z-10">
               <Suspense fallback={<SkeletonMap />}>
                 <SiteDetailView
                   sites={filteredSites}

--- a/src/components/Layout/DesktopLayout.tsx
+++ b/src/components/Layout/DesktopLayout.tsx
@@ -108,7 +108,7 @@ export function DesktopLayout({
         {/* Center & Right - Filter bar, Maps side by side + Timeline below */}
         <div className="flex-1 min-w-0 pr-6 flex flex-col">
           {/* Filter bar - Horizontal component with compact padding */}
-          <div className={`flex-shrink-0 mt-4 py-3 backdrop-blur-sm border-2 border-[#000000] rounded-lg shadow-xl relative z-[5] transition-colors duration-200 ${isDark ? "bg-[#000000]/90" : "bg-white/90"}`}>
+          <div className={`flex-shrink-0 mt-4 py-3 backdrop-blur-sm border-2 border-[#000000] rounded-lg shadow-xl relative z-[5] transition-colors duration-200 ${isDark ? "bg-[#000000]/95" : "bg-white/95"}`}>
             <div className="flex items-start gap-4 px-3">
               {/* Left side - Filter controls */}
               <div className="flex-1 flex items-center gap-3 flex-wrap">

--- a/src/components/Layout/DesktopLayout.tsx
+++ b/src/components/Layout/DesktopLayout.tsx
@@ -116,7 +116,7 @@ export function DesktopLayout({
         {/* Center & Right - Filter bar, Maps side by side + Timeline below */}
         <div className="flex-1 min-w-0 pr-6 flex flex-col">
           {/* Filter bar - Horizontal component with compact padding */}
-          <div className={`flex-shrink-0 mt-4 py-3 backdrop-blur-sm border-2 border-[#000000] rounded-lg shadow-xl relative z-[5] transition-colors duration-200 ${isDark ? "bg-[#000000]/95" : "bg-white/95"}`}>
+          <div className={`flex-shrink-0 mt-4 py-3 backdrop-blur-sm border-2 border-[#000000] rounded-lg shadow-2xl-dark relative z-[5] transition-colors duration-200 ${isDark ? "bg-[#000000]/95" : "bg-white/95"}`}>
             <div className="flex flex-col gap-2">
               {/* Top row - Filter controls and legend */}
               <div className="flex items-start gap-4 px-3">
@@ -255,7 +255,7 @@ export function DesktopLayout({
           {/* Two maps side by side - Constrained height to leave room for timeline */}
           <div className="flex gap-4 min-h-0 pt-3" style={{ height: 'calc(100% - 270px)' }}>
             {/* Center - Heritage Map (Traditional/Satellite toggle) */}
-            <div className="flex-1 min-w-0 h-full border-2 border-[#000000] rounded-lg shadow-xl overflow-hidden relative z-10">
+            <div className="flex-1 min-w-0 h-full border-2 border-[#000000] rounded-lg shadow-2xl-dark overflow-hidden relative z-10">
               <Suspense fallback={<SkeletonMap />}>
                 <HeritageMap
                   sites={filteredSites}
@@ -267,7 +267,7 @@ export function DesktopLayout({
             </div>
 
             {/* Right - Site Detail View (Satellite only, zooms on selection) */}
-            <div className="flex-1 min-w-0 h-full border-2 border-[#000000] rounded-lg shadow-xl overflow-hidden relative z-10">
+            <div className="flex-1 min-w-0 h-full border-2 border-[#000000] rounded-lg shadow-2xl-dark overflow-hidden relative z-10">
               <Suspense fallback={<SkeletonMap />}>
                 <SiteDetailView
                   sites={filteredSites}

--- a/src/components/Map/HeritageMap.tsx
+++ b/src/components/Map/HeritageMap.tsx
@@ -70,6 +70,7 @@ export function HeritageMap({
           highlightedSiteId={highlightedSiteId}
           onSiteClick={onSiteClick}
           onSiteHighlight={onSiteHighlight}
+          currentTimestamp={currentTimestamp}
         />
       </MapContainer>
     </div>

--- a/src/components/Map/HeritageMap.tsx
+++ b/src/components/Map/HeritageMap.tsx
@@ -43,12 +43,6 @@ export function HeritageMap({
 
   return (
     <div className="relative h-full bg-white/90 backdrop-blur-sm">
-      {/* Map interaction hint */}
-      <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 z-[1000] bg-white/90 backdrop-blur-sm px-4 py-2 rounded-lg shadow-md text-xs text-gray-700 pointer-events-none">
-        Use <kbd className="px-1.5 py-0.5 bg-gray-200 rounded text-[10px] font-semibold">Ctrl</kbd>{" "}
-        + scroll to zoom • Click markers for details
-      </div>
-
       <MapContainer
         center={GAZA_CENTER}
         zoom={DEFAULT_ZOOM}

--- a/src/components/Map/SiteDetailView.test.tsx
+++ b/src/components/Map/SiteDetailView.test.tsx
@@ -101,15 +101,14 @@ describe("SiteDetailView", () => {
     expect(container).toBeInTheDocument();
   });
 
-  it("shows Gaza overview label when no site is highlighted", () => {
+  it("renders map when no site is highlighted", () => {
     renderWithAnimation(<SiteDetailView sites={mockSites} highlightedSiteId={null} />);
-    expect(screen.getByText("Gaza Overview (Satellite)")).toBeInTheDocument();
+    expect(screen.getByTestId("map-container")).toBeInTheDocument();
   });
 
-  it("shows site detail label when a site is highlighted", () => {
+  it("shows marker when a site is highlighted", () => {
     renderWithAnimation(<SiteDetailView sites={mockSites} highlightedSiteId="1" />);
-    expect(screen.getByText("Site Detail (Satellite)")).toBeInTheDocument();
-    expect(screen.getByText("Great Omari Mosque")).toBeInTheDocument();
+    expect(screen.getByTestId("marker")).toBeInTheDocument();
   });
 
   it("renders satellite tile layer", () => {
@@ -117,53 +116,53 @@ describe("SiteDetailView", () => {
     expect(container).toBeInTheDocument();
   });
 
-  it("shows overview label when no site is highlighted", () => {
+  it("renders map when no site is highlighted (duplicate test)", () => {
     renderWithAnimation(<SiteDetailView sites={mockSites} highlightedSiteId={null} />);
-    expect(screen.getByText("Gaza Overview (Satellite)")).toBeInTheDocument();
+    expect(screen.getByTestId("map-container")).toBeInTheDocument();
   });
 
-  it("shows site name when a site is highlighted", () => {
+  it("shows marker when a site is highlighted (duplicate test)", () => {
     renderWithAnimation(<SiteDetailView sites={mockSites} highlightedSiteId="1" />);
-    expect(screen.getByText("Great Omari Mosque")).toBeInTheDocument();
-    expect(screen.getByText("Site Detail (Satellite)")).toBeInTheDocument();
+    expect(screen.getByTestId("marker")).toBeInTheDocument();
   });
 
   it("handles invalid highlightedSiteId gracefully", () => {
     renderWithAnimation(<SiteDetailView sites={mockSites} highlightedSiteId="invalid-id" />);
-    expect(screen.getByText("Gaza Overview (Satellite)")).toBeInTheDocument();
+    expect(screen.getByTestId("map-container")).toBeInTheDocument();
     expect(screen.queryByTestId("marker")).not.toBeInTheDocument();
   });
 
   it("handles empty sites array", () => {
     renderWithAnimation(<SiteDetailView sites={[]} highlightedSiteId={null} />);
-    expect(screen.getByText("Gaza Overview (Satellite)")).toBeInTheDocument();
+    expect(screen.getByTestId("map-container")).toBeInTheDocument();
   });
 
   it("updates when highlightedSiteId changes", () => {
     renderWithAnimation(
       <SiteDetailView sites={mockSites} highlightedSiteId={null} />
     );
-    expect(screen.getByText("Gaza Overview (Satellite)")).toBeInTheDocument();
+    expect(screen.getByTestId("map-container")).toBeInTheDocument();
 
     // Need to call renderWithAnimation helper which wraps with ThemeProvider
     renderWithAnimation(
       <SiteDetailView sites={mockSites} highlightedSiteId="1" />
     );
-    expect(screen.getByText("Site Detail (Satellite)")).toBeInTheDocument();
-    expect(screen.getByText("Great Omari Mosque")).toBeInTheDocument();
+    expect(screen.getByTestId("marker")).toBeInTheDocument();
   });
 
   it("switches between different highlighted sites", () => {
-    renderWithAnimation(
+    const { rerender } = renderWithAnimation(
       <SiteDetailView sites={mockSites} highlightedSiteId="1" />
     );
-    expect(screen.getByText("Great Omari Mosque")).toBeInTheDocument();
+    expect(screen.getByTestId("marker")).toBeInTheDocument();
 
-    // Need to call renderWithAnimation helper which wraps with ThemeProvider
-    renderWithAnimation(
-      <SiteDetailView sites={mockSites} highlightedSiteId="2" />
+    // Rerender with different site
+    rerender(
+      <AnimationProvider sites={mockSites}>
+        <SiteDetailView sites={mockSites} highlightedSiteId="2" />
+      </AnimationProvider>
     );
-    expect(screen.getByText("Al-Saqqa Mosque")).toBeInTheDocument();
+    expect(screen.getByTestId("marker")).toBeInTheDocument();
   });
 
   it("renders TimeToggle component", () => {
@@ -174,19 +173,16 @@ describe("SiteDetailView", () => {
     expect(screen.getByLabelText("Switch to Current satellite imagery")).toBeInTheDocument();
   });
 
-  it("displays time period label when no site is highlighted", () => {
+  it("renders time period toggle when no site is highlighted", () => {
     renderWithAnimation(<SiteDetailView sites={mockSites} highlightedSiteId={null} />);
-    // The label should show the period label - timeline starts at Dec 7, 2023 (first destruction)
-    // so it will automatically sync to "Current" period
-    expect(screen.getByText("Gaza Overview (Satellite)")).toBeInTheDocument();
-    // "Current" appears in both the TimeToggle button and the period label, so we just verify the overview text
-    const currentTexts = screen.getAllByText("Current");
-    expect(currentTexts.length).toBeGreaterThan(0);
+    // TimeToggle should be present
+    expect(screen.getByTestId("time-toggle")).toBeInTheDocument();
   });
 
-  it("shows site name instead of period label when site is highlighted", () => {
+  it("renders time period toggle when site is highlighted", () => {
     renderWithAnimation(<SiteDetailView sites={mockSites} highlightedSiteId="1" />);
-    // When a site is highlighted, the site name is shown in the label area
-    expect(screen.getByText("Great Omari Mosque")).toBeInTheDocument();
+    // TimeToggle should be present with marker
+    expect(screen.getByTestId("time-toggle")).toBeInTheDocument();
+    expect(screen.getByTestId("marker")).toBeInTheDocument();
   });
 });

--- a/src/components/Map/SiteDetailView.test.tsx
+++ b/src/components/Map/SiteDetailView.test.tsx
@@ -4,7 +4,21 @@ import { SiteDetailView } from "./SiteDetailView";
 import { AnimationProvider } from "../../contexts/AnimationContext";
 import type { GazaSite } from "../../types";
 
-// Mock Leaflet components
+// Mock Leaflet library
+vi.mock("leaflet", () => ({
+  default: {
+    divIcon: vi.fn(() => ({})),
+    Icon: {
+      Default: {
+        prototype: {
+          options: {},
+        },
+      },
+    },
+  },
+}));
+
+// Mock react-leaflet components
 vi.mock("react-leaflet", () => ({
   MapContainer: ({ children, className }: { children?: React.ReactNode; className?: string; [key: string]: unknown }) => (
     <div data-testid="map-container" className={className}>
@@ -25,13 +39,6 @@ vi.mock("react-leaflet", () => ({
     setZoom: vi.fn(),
   }),
   useMapEvents: () => ({}),
-}));
-
-// Mock Leaflet library
-vi.mock("leaflet", () => ({
-  default: {
-    divIcon: vi.fn(() => ({})),
-  },
 }));
 
 // Mock MapHelperComponents

--- a/src/components/Map/SiteDetailView.tsx
+++ b/src/components/Map/SiteDetailView.tsx
@@ -63,11 +63,6 @@ export function SiteDetailView({ sites, highlightedSiteId, syncMapToTimeline = f
     };
   }, [selectedPeriod]);
 
-  // Get label for selected time period
-  const periodLabel = useMemo(() => {
-    return HISTORICAL_IMAGERY[selectedPeriod].label;
-  }, [selectedPeriod]);
-
   // Determine map center and zoom level (clamped to period's max zoom)
   const { center, zoom } = useMemo(() => {
     if (highlightedSite) {
@@ -100,16 +95,6 @@ export function SiteDetailView({ sites, highlightedSiteId, syncMapToTimeline = f
     <div className="relative h-full">
       {/* Time period toggle */}
       <TimeToggle selectedPeriod={selectedPeriod} onPeriodChange={setSelectedPeriod} />
-
-      {/* Label for the detail view */}
-      <div className="absolute top-2 left-2 z-[1000] bg-white/90 backdrop-blur-sm px-3 py-1.5 rounded-lg shadow-md pointer-events-none">
-        <div className="text-xs font-semibold text-gray-900">
-          {highlightedSite ? "Site Detail (Satellite)" : "Gaza Overview (Satellite)"}
-        </div>
-        <div className="text-[10px] text-gray-600 mt-0.5">
-          {highlightedSite ? highlightedSite.name : periodLabel}
-        </div>
-      </div>
 
       <MapContainer
         center={center}

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -7,21 +7,21 @@ describe("Modal", () => {
     const mockOnClose = vi.fn();
 
     renderWithTheme(
-      <Modal isOpen={true} onClose={mockOnClose} title="Test Modal">
+      <Modal isOpen={true} onClose={mockOnClose}>
         <div>Test content</div>
       </Modal>
     );
 
     expect(screen.getByRole("dialog")).toBeInTheDocument();
-    expect(screen.getByText("Test Modal")).toBeInTheDocument();
     expect(screen.getByText("Test content")).toBeInTheDocument();
+    expect(screen.getByLabelText("Close modal")).toBeInTheDocument();
   });
 
   it("does not render when closed", () => {
     const mockOnClose = vi.fn();
 
     const { container } = renderWithTheme(
-      <Modal isOpen={false} onClose={mockOnClose} title="Test Modal">
+      <Modal isOpen={false} onClose={mockOnClose}>
         <div>Test content</div>
       </Modal>
     );

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -78,46 +78,29 @@ export function Modal({ isOpen, onClose, children, title, zIndex = 9999 }: Modal
           t.card.base
         )}
       >
-        {/* Header with close button */}
-        <div className={cn(
-          "sticky top-0 z-20 px-6 py-4 flex items-center justify-between",
-          t.bg.primary,
-          t.border.default,
-          "border-b"
-        )}>
-          {title && (
-            <h2 id="modal-title" className={cn(
-              "text-2xl font-bold",
-              t.text.heading
-            )}>
-              {title}
-            </h2>
+        {/* Close button - positioned at top right of content */}
+        <button
+          onClick={onClose}
+          className={cn(
+            "absolute top-4 right-8 z-30 p-2 cursor-pointer",
+            t.text.muted
           )}
-          <button
-            onClick={onClose}
-            className={cn(
-              "ml-auto p-2 rounded-lg transition-colors",
-              t.bg.hover,
-              t.text.muted,
-              "hover:text-gray-700"
-            )}
-            aria-label="Close modal"
+          aria-label="Close modal"
+        >
+          <svg
+            className="w-6 h-6"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
           >
-            <svg
-              className="w-6 h-6"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
-        </div>
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
 
         {/* Modal Body */}
         <div className="px-6 py-4">{children}</div>

--- a/src/components/SitesTable/SitesTableDesktop.tsx
+++ b/src/components/SitesTable/SitesTableDesktop.tsx
@@ -168,7 +168,7 @@ export function SitesTableDesktop({
                            px-4 py-2 bg-[#009639] hover:bg-[#007b2f] text-white
                            rounded-lg shadow-md hover:shadow-lg
                            transition-all duration-200 font-semibold
-                           active:scale-95 text-sm"
+                           active:scale-95 text-sm mr-12"
                 title="Export table data to CSV file"
                 aria-label="Export to CSV"
               >
@@ -304,8 +304,8 @@ export function SitesTableDesktop({
                 {isColumnVisible("type") && (
                   <td className={`${components.table.td} text-center`}>
                     <Tooltip content={getSiteTypeLabel(site.type)}>
-                      <span className={`inline-flex items-center justify-center px-2 py-1.5 text-xs font-medium rounded ${t.bg.secondary} ${t.text.body}`}>
-                        <SiteTypeIcon type={site.type} className="w-5 h-5" />
+                      <span className="inline-flex items-center justify-center">
+                        <SiteTypeIcon type={site.type} className={`w-5 h-5 ${t.text.body}`} />
                       </span>
                     </Tooltip>
                   </td>

--- a/src/components/SitesTable/SitesTableDesktop.tsx
+++ b/src/components/SitesTable/SitesTableDesktop.tsx
@@ -168,7 +168,7 @@ export function SitesTableDesktop({
                            px-4 py-2 bg-[#009639] hover:bg-[#007b2f] text-white
                            rounded-lg shadow-md hover:shadow-lg
                            transition-all duration-200 font-semibold
-                           active:scale-95 text-sm mr-12"
+                           active:scale-95 text-sm border border-[#000000] mr-12"
                 title="Export table data to CSV file"
                 aria-label="Export to CSV"
               >

--- a/src/components/SitesTable/SitesTableDesktop.tsx
+++ b/src/components/SitesTable/SitesTableDesktop.tsx
@@ -136,9 +136,9 @@ export function SitesTableDesktop({
   }, [highlightedSiteId]);
 
   return (
-    <div className={`flex flex-col backdrop-blur-sm border-2 border-[#000000] rounded-lg shadow-xl transition-colors duration-200 ${isDark ? "bg-[#000000]/50" : "bg-white/50"}`} style={{ height: 'calc(100% - 4px)' }}>
+    <div className={`flex flex-col backdrop-blur-sm border-2 border-[#000000] rounded-lg shadow-xl transition-colors duration-200 ${isDark ? "bg-[#000000]/95" : "bg-white/95"}`} style={{ height: 'calc(100% - 4px)' }}>
       {/* Title section - sticky */}
-      <div className={`sticky top-0 z-20 backdrop-blur-sm flex-shrink-0 shadow-sm rounded-t-lg transition-colors duration-200 ${isDark ? "bg-[#000000]/50" : "bg-white/50"}`}>
+      <div className={`sticky top-0 z-20 backdrop-blur-sm flex-shrink-0 shadow-sm rounded-t-lg transition-colors duration-200 ${isDark ? "bg-[#000000]/95" : "bg-white/95"}`}>
         <div className="px-2 pt-4 pb-2">
           <div className="flex items-center justify-between">
             <div className="flex items-center justify-center gap-2 flex-1">

--- a/src/components/SitesTable/SitesTableDesktop.tsx
+++ b/src/components/SitesTable/SitesTableDesktop.tsx
@@ -287,7 +287,7 @@ export function SitesTableDesktop({
                       }}
                       className="text-left w-full hover:underline"
                     >
-                      <div className="font-semibold text-[#009639] hover:text-[#007b2f]">{site.name}</div>
+                      <div className="font-semibold text-base text-[#009639] hover:text-[#007b2f]">{site.name}</div>
                       {site.nameArabic && (
                         <div
                           className={`${

--- a/src/components/SitesTable/SitesTableDesktop.tsx
+++ b/src/components/SitesTable/SitesTableDesktop.tsx
@@ -136,7 +136,7 @@ export function SitesTableDesktop({
   }, [highlightedSiteId]);
 
   return (
-    <div className={`flex flex-col backdrop-blur-sm border-2 border-[#000000] rounded-lg shadow-xl transition-colors duration-200 ${isDark ? "bg-[#000000]/95" : "bg-white/95"}`} style={{ height: 'calc(100% - 4px)' }}>
+    <div className={`flex flex-col backdrop-blur-sm border-2 border-[#000000] rounded-lg shadow-2xl-dark transition-colors duration-200 ${isDark ? "bg-[#000000]/95" : "bg-white/95"}`} style={{ height: 'calc(100% - 4px)' }}>
       {/* Title section - sticky */}
       <div className={`sticky top-0 z-20 backdrop-blur-sm flex-shrink-0 shadow-sm rounded-t-lg transition-colors duration-200 ${isDark ? "bg-[#000000]/95" : "bg-white/95"}`}>
         <div className="px-2 pt-4 pb-2">

--- a/src/components/Timeline/TimelineScrubber.tsx
+++ b/src/components/Timeline/TimelineScrubber.tsx
@@ -226,6 +226,9 @@ export function TimelineScrubber({
   // Speed options
   const speedOptions: AnimationSpeed[] = [0.5, 1, 2, 4];
 
+  // Check if timeline is at the start position
+  const isAtStart = currentTimestamp.getTime() === startDate.getTime();
+
   return (
     <div
       ref={containerRef}
@@ -258,7 +261,12 @@ export function TimelineScrubber({
           )}
           <button
             onClick={reset}
-            className={`flex items-center gap-2 px-4 py-2 rounded-lg shadow-md hover:shadow-lg transition-all duration-200 text-sm font-semibold active:scale-95 border border-[#000000] ${t.bg.secondary} ${t.bg.hover} ${t.text.body}`}
+            disabled={isAtStart}
+            className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-all duration-200 text-sm font-semibold border border-[#000000] ${
+              isAtStart
+                ? "bg-gray-300 text-gray-500 cursor-not-allowed shadow-none"
+                : `shadow-md hover:shadow-lg active:scale-95 ${t.bg.secondary} ${t.bg.hover} ${t.text.body}`
+            }`}
             aria-label="Reset timeline to start"
           >
             <ArrowPathIcon className="w-4 h-4" />

--- a/src/components/Timeline/TimelineScrubber.tsx
+++ b/src/components/Timeline/TimelineScrubber.tsx
@@ -229,7 +229,7 @@ export function TimelineScrubber({
   return (
     <div
       ref={containerRef}
-      className={`backdrop-blur-sm border-2 border-[#000000] rounded-lg p-3 shadow-xl transition-colors duration-200 ${isDark ? "bg-[#000000]/95" : "bg-white/95"}`}
+      className={`backdrop-blur-sm border-2 border-[#000000] rounded-lg p-3 shadow-2xl-dark transition-colors duration-200 ${isDark ? "bg-[#000000]/95" : "bg-white/95"}`}
       role="region"
       aria-label="Timeline Scrubber"
     >

--- a/src/components/Timeline/TimelineScrubber.tsx
+++ b/src/components/Timeline/TimelineScrubber.tsx
@@ -182,9 +182,9 @@ export function TimelineScrubber({ sites, onSyncMapChange }: TimelineScrubberPro
       aria-label="Timeline Scrubber"
     >
       {/* Controls */}
-      <div className="flex items-center justify-between mb-3 gap-4">
+      <div className="flex items-center mb-3 gap-4">
         {/* Left: Play/Pause/Reset/Sync Map/Speed */}
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-1">
           {!isPlaying ? (
             <button
               onClick={play}
@@ -248,11 +248,14 @@ export function TimelineScrubber({ sites, onSyncMapChange }: TimelineScrubberPro
           </div>
         </div>
 
-        {/* Right: Current date display */}
-        <div className={`text-sm font-semibold ${isDark ? "text-[#fefefe]" : t.text.heading}`}>
+        {/* Center: Current date display */}
+        <div className={`text-sm font-semibold text-center flex-1 ${isDark ? "text-[#fefefe]" : t.text.heading}`}>
           <span className={t.text.muted}>Current:</span>{" "}
           {d3.timeFormat("%B %d, %Y")(currentTimestamp)}
         </div>
+
+        {/* Right: Empty spacer for balance */}
+        <div className="flex-1"></div>
       </div>
 
       {/* D3 Timeline SVG */}

--- a/src/components/Timeline/TimelineScrubber.tsx
+++ b/src/components/Timeline/TimelineScrubber.tsx
@@ -258,7 +258,7 @@ export function TimelineScrubber({
           )}
           <button
             onClick={reset}
-            className={`flex items-center gap-2 px-4 py-2 text-[#fefefe] rounded-lg shadow-md hover:shadow-lg transition-all duration-200 text-sm font-semibold active:scale-95 ${t.bg.secondary} ${t.bg.hover}`}
+            className={`flex items-center gap-2 px-4 py-2 rounded-lg shadow-md hover:shadow-lg transition-all duration-200 text-sm font-semibold active:scale-95 ${t.bg.secondary} ${t.bg.hover} ${t.text.body}`}
             aria-label="Reset timeline to start"
           >
             <ArrowPathIcon className="w-4 h-4" />

--- a/src/components/Timeline/TimelineScrubber.tsx
+++ b/src/components/Timeline/TimelineScrubber.tsx
@@ -177,7 +177,7 @@ export function TimelineScrubber({ sites, onSyncMapChange }: TimelineScrubberPro
   return (
     <div
       ref={containerRef}
-      className={`backdrop-blur-sm border-2 border-[#000000] rounded-lg p-3 shadow-xl transition-colors duration-200 ${isDark ? "bg-[#000000]/90" : "bg-white/90"}`}
+      className={`backdrop-blur-sm border-2 border-[#000000] rounded-lg p-3 shadow-xl transition-colors duration-200 ${isDark ? "bg-[#000000]/95" : "bg-white/95"}`}
       role="region"
       aria-label="Timeline Scrubber"
     >

--- a/src/components/Timeline/TimelineScrubber.tsx
+++ b/src/components/Timeline/TimelineScrubber.tsx
@@ -183,7 +183,7 @@ export function TimelineScrubber({ sites, onSyncMapChange }: TimelineScrubberPro
     >
       {/* Controls */}
       <div className="flex items-center justify-between mb-3 gap-4">
-        {/* Left: Play/Pause/Reset */}
+        {/* Left: Play/Pause/Reset/Sync Map/Speed */}
         <div className="flex items-center gap-2">
           {!isPlaying ? (
             <button
@@ -226,32 +226,32 @@ export function TimelineScrubber({ sites, onSyncMapChange }: TimelineScrubberPro
           >
             <span>{syncMap ? "✓" : ""} Sync Map</span>
           </button>
+
+          {/* Speed control */}
+          <div className="flex items-center gap-2">
+            <label htmlFor="speed-control" className={`text-sm font-medium ${t.text.body}`}>
+              Speed:
+            </label>
+            <select
+              id="speed-control"
+              value={speed}
+              onChange={(e) => setSpeed(Number(e.target.value) as AnimationSpeed)}
+              className={`px-2 py-2 border rounded-md text-sm focus:ring-2 focus:ring-[#009639] focus:border-[#009639] ${t.input.base}`}
+              aria-label="Animation speed control"
+            >
+              {speedOptions.map((s) => (
+                <option key={s} value={s}>
+                  {s}x
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
 
-        {/* Center: Current date display */}
+        {/* Right: Current date display */}
         <div className={`text-sm font-semibold ${isDark ? "text-[#fefefe]" : t.text.heading}`}>
           <span className={t.text.muted}>Current:</span>{" "}
           {d3.timeFormat("%B %d, %Y")(currentTimestamp)}
-        </div>
-
-        {/* Right: Speed control */}
-        <div className="flex items-center gap-2">
-          <label htmlFor="speed-control" className={`text-sm font-medium ${t.text.body}`}>
-            Speed:
-          </label>
-          <select
-            id="speed-control"
-            value={speed}
-            onChange={(e) => setSpeed(Number(e.target.value) as AnimationSpeed)}
-            className={`px-2 py-2 border rounded-md text-sm focus:ring-2 focus:ring-[#009639] focus:border-[#009639] ${t.input.base}`}
-            aria-label="Animation speed control"
-          >
-            {speedOptions.map((s) => (
-              <option key={s} value={s}>
-                {s}x
-              </option>
-            ))}
-          </select>
         </div>
       </div>
 

--- a/src/components/Timeline/TimelineScrubber.tsx
+++ b/src/components/Timeline/TimelineScrubber.tsx
@@ -240,7 +240,7 @@ export function TimelineScrubber({
           {!isPlaying ? (
             <button
               onClick={play}
-              className="flex items-center gap-2 px-4 py-2 bg-[#009639] text-[#fefefe] hover:bg-[#007b2f] rounded-lg shadow-md hover:shadow-lg transition-all duration-200 text-sm font-semibold active:scale-95"
+              className="flex items-center gap-2 px-4 py-2 bg-[#009639] text-[#fefefe] hover:bg-[#007b2f] rounded-lg shadow-md hover:shadow-lg transition-all duration-200 text-sm font-semibold active:scale-95 border border-[#000000]"
               aria-label="Play timeline animation"
             >
               <PlayIcon className="w-4 h-4" />
@@ -249,7 +249,7 @@ export function TimelineScrubber({
           ) : (
             <button
               onClick={pause}
-              className="flex items-center gap-2 px-4 py-2 bg-[#ed3039] text-[#fefefe] hover:bg-[#d4202a] rounded-lg shadow-md hover:shadow-lg transition-all duration-200 text-sm font-semibold active:scale-95"
+              className="flex items-center gap-2 px-4 py-2 bg-[#ed3039] text-[#fefefe] hover:bg-[#d4202a] rounded-lg shadow-md hover:shadow-lg transition-all duration-200 text-sm font-semibold active:scale-95 border border-[#000000]"
               aria-label="Pause timeline animation"
             >
               <PauseIcon className="w-4 h-4" />
@@ -258,7 +258,7 @@ export function TimelineScrubber({
           )}
           <button
             onClick={reset}
-            className={`flex items-center gap-2 px-4 py-2 rounded-lg shadow-md hover:shadow-lg transition-all duration-200 text-sm font-semibold active:scale-95 ${t.bg.secondary} ${t.bg.hover} ${t.text.body}`}
+            className={`flex items-center gap-2 px-4 py-2 rounded-lg shadow-md hover:shadow-lg transition-all duration-200 text-sm font-semibold active:scale-95 border border-[#000000] ${t.bg.secondary} ${t.bg.hover} ${t.text.body}`}
             aria-label="Reset timeline to start"
           >
             <ArrowPathIcon className="w-4 h-4" />
@@ -268,7 +268,7 @@ export function TimelineScrubber({
           {/* Sync Map toggle button */}
           <button
             onClick={() => setSyncMap(!syncMap)}
-            className={`flex items-center gap-2 px-4 py-2 rounded-lg shadow-md hover:shadow-lg transition-all duration-200 text-sm font-semibold active:scale-95 ${
+            className={`flex items-center gap-2 px-4 py-2 rounded-lg shadow-md hover:shadow-lg transition-all duration-200 text-sm font-semibold active:scale-95 border border-[#000000] ${
               syncMap
                 ? `${t.flag.greenBg} text-[#fefefe] ${t.flag.greenHover}`
                 : `${t.bg.active} ${t.text.body} ${t.bg.hover}`
@@ -337,7 +337,7 @@ export function TimelineScrubber({
               onDestructionDateStartChange(null);
               onDestructionDateEndChange(null);
             }}
-            className={`flex items-center gap-2 px-3 py-1.5 rounded-lg shadow-md hover:shadow-lg transition-all duration-200 text-xs font-semibold active:scale-95 ${
+            className={`flex items-center gap-2 px-3 py-1.5 rounded-lg shadow-md hover:shadow-lg transition-all duration-200 text-xs font-semibold active:scale-95 border border-[#000000] ${
               destructionDateStart || destructionDateEnd
                 ? `${t.bg.secondary} ${t.text.body} ${t.bg.hover}`
                 : "invisible"

--- a/src/components/Timeline/TimelineScrubber.tsx
+++ b/src/components/Timeline/TimelineScrubber.tsx
@@ -16,6 +16,10 @@ import { Input } from "../Form/Input";
 interface TimelineScrubberProps {
   sites: GazaSite[];
   onSyncMapChange?: (isSynced: boolean) => void; // Optional callback for map sync toggle
+  destructionDateStart: Date | null;
+  destructionDateEnd: Date | null;
+  onDestructionDateStartChange: (date: Date | null) => void;
+  onDestructionDateEndChange: (date: Date | null) => void;
 }
 
 /**
@@ -29,7 +33,14 @@ interface TimelineScrubberProps {
  * - Keyboard navigation (space, arrows, home/end)
  * - Responsive to container width changes
  */
-export function TimelineScrubber({ sites, onSyncMapChange }: TimelineScrubberProps) {
+export function TimelineScrubber({
+  sites,
+  onSyncMapChange,
+  destructionDateStart,
+  destructionDateEnd,
+  onDestructionDateStartChange,
+  onDestructionDateEndChange,
+}: TimelineScrubberProps) {
   const {
     currentTimestamp,
     isPlaying,
@@ -66,10 +77,6 @@ export function TimelineScrubber({ sites, onSyncMapChange }: TimelineScrubberPro
     };
   }, [allDestructionDates, startDate, endDate]);
 
-  // Date filter state for timeline - null means use default range
-  const [filterStartDate, setFilterStartDate] = useState<Date | null>(null);
-  const [filterEndDate, setFilterEndDate] = useState<Date | null>(null);
-
   // Notify parent when sync state changes
   useEffect(() => {
     onSyncMapChange?.(syncMap);
@@ -84,15 +91,15 @@ export function TimelineScrubber({ sites, onSyncMapChange }: TimelineScrubberPro
 
   // Filter destruction dates based on date filter
   const destructionDates = useMemo(() => {
-    if (!filterStartDate && !filterEndDate) {
+    if (!destructionDateStart && !destructionDateEnd) {
       return allDestructionDates;
     }
     return allDestructionDates.filter((event) => {
-      if (filterStartDate && event.date < filterStartDate) return false;
-      if (filterEndDate && event.date > filterEndDate) return false;
+      if (destructionDateStart && event.date < destructionDateStart) return false;
+      if (destructionDateEnd && event.date > destructionDateEnd) return false;
       return true;
     });
-  }, [allDestructionDates, filterStartDate, filterEndDate]);
+  }, [allDestructionDates, destructionDateStart, destructionDateEnd]);
 
   // Calculate adjusted timeline range based on filtered dates
   const { adjustedStartDate, adjustedEndDate } = useMemo(() => {
@@ -105,10 +112,10 @@ export function TimelineScrubber({ sites, onSyncMapChange }: TimelineScrubberPro
     const maxDate = new Date(Math.max(...destructionDates.map((event) => event.date.getTime())));
 
     return {
-      adjustedStartDate: filterStartDate || filterEndDate ? minDate : startDate,
-      adjustedEndDate: filterStartDate || filterEndDate ? maxDate : endDate,
+      adjustedStartDate: destructionDateStart || destructionDateEnd ? minDate : startDate,
+      adjustedEndDate: destructionDateStart || destructionDateEnd ? maxDate : endDate,
     };
-  }, [destructionDates, startDate, endDate, filterStartDate, filterEndDate]);
+  }, [destructionDates, startDate, endDate, destructionDateStart, destructionDateEnd]);
 
   // Observe container width changes
   useEffect(() => {
@@ -306,9 +313,9 @@ export function TimelineScrubber({ sites, onSyncMapChange }: TimelineScrubberPro
           </label>
           <Input
             variant="date"
-            value={(filterStartDate || defaultStartDate).toISOString().split("T")[0]}
+            value={(destructionDateStart || defaultStartDate).toISOString().split("T")[0]}
             onChange={(e) => {
-              setFilterStartDate(e.target.value ? new Date(e.target.value) : null);
+              onDestructionDateStartChange(e.target.value ? new Date(e.target.value) : null);
             }}
             placeholder="From"
             className="flex-none w-32 text-xs py-1.5 px-2"
@@ -316,9 +323,9 @@ export function TimelineScrubber({ sites, onSyncMapChange }: TimelineScrubberPro
           <span className={`text-xs font-medium ${t.text.body}`}>to</span>
           <Input
             variant="date"
-            value={(filterEndDate || defaultEndDate).toISOString().split("T")[0]}
+            value={(destructionDateEnd || defaultEndDate).toISOString().split("T")[0]}
             onChange={(e) => {
-              setFilterEndDate(e.target.value ? new Date(e.target.value) : null);
+              onDestructionDateEndChange(e.target.value ? new Date(e.target.value) : null);
             }}
             placeholder="To"
             className="flex-none w-32 text-xs py-1.5 px-2"
@@ -327,16 +334,16 @@ export function TimelineScrubber({ sites, onSyncMapChange }: TimelineScrubberPro
           {/* Clear Date Filter button - always reserve space, only visible when filter is active */}
           <button
             onClick={() => {
-              setFilterStartDate(null);
-              setFilterEndDate(null);
+              onDestructionDateStartChange(null);
+              onDestructionDateEndChange(null);
             }}
             className={`flex items-center gap-2 px-3 py-1.5 rounded-lg shadow-md hover:shadow-lg transition-all duration-200 text-xs font-semibold active:scale-95 ${
-              filterStartDate || filterEndDate
+              destructionDateStart || destructionDateEnd
                 ? `${t.bg.secondary} ${t.text.body} ${t.bg.hover}`
                 : "invisible"
             }`}
             aria-label="Clear date filter"
-            disabled={!filterStartDate && !filterEndDate}
+            disabled={!destructionDateStart && !destructionDateEnd}
           >
             Clear Date Filter
           </button>

--- a/src/hooks/useAppState.ts
+++ b/src/hooks/useAppState.ts
@@ -70,6 +70,15 @@ export function useAppState() {
     creationYearEnd !== null ||
     searchTerm.trim().length > 0;
 
+  // Check if temp filters have unapplied changes
+  const hasUnappliedChanges =
+    JSON.stringify(tempSelectedTypes.sort()) !== JSON.stringify(selectedTypes.sort()) ||
+    JSON.stringify(tempSelectedStatuses.sort()) !== JSON.stringify(selectedStatuses.sort()) ||
+    tempDestructionDateStart?.getTime() !== destructionDateStart?.getTime() ||
+    tempDestructionDateEnd?.getTime() !== destructionDateEnd?.getTime() ||
+    tempCreationYearStart !== creationYearStart ||
+    tempCreationYearEnd !== creationYearEnd;
+
   // Clear all filters
   const clearAllFilters = useCallback(() => {
     setSelectedTypes([]);
@@ -152,6 +161,7 @@ export function useAppState() {
     setCreationYearEnd,
     setSearchTerm,
     hasActiveFilters,
+    hasUnappliedChanges,
     clearAllFilters,
 
     // Temp filters (for modal)

--- a/src/hooks/useAppState.ts
+++ b/src/hooks/useAppState.ts
@@ -79,6 +79,15 @@ export function useAppState() {
     tempCreationYearStart !== creationYearStart ||
     tempCreationYearEnd !== creationYearEnd;
 
+  // Check if temp filters are empty (for Clear All button state)
+  const hasTempFilters =
+    tempSelectedTypes.length > 0 ||
+    tempSelectedStatuses.length > 0 ||
+    tempDestructionDateStart !== null ||
+    tempDestructionDateEnd !== null ||
+    tempCreationYearStart !== null ||
+    tempCreationYearEnd !== null;
+
   // Clear all filters
   const clearAllFilters = useCallback(() => {
     setSelectedTypes([]);
@@ -162,6 +171,7 @@ export function useAppState() {
     setSearchTerm,
     hasActiveFilters,
     hasUnappliedChanges,
+    hasTempFilters,
     clearAllFilters,
 
     // Temp filters (for modal)

--- a/src/hooks/useThemeClasses.ts
+++ b/src/hooks/useThemeClasses.ts
@@ -82,7 +82,7 @@ export function useThemeClasses() {
       /** Base input styling */
       base: isDark
         ? "bg-gray-700 border-gray-600 text-gray-100 placeholder:text-gray-400"
-        : "bg-white border-gray-200 text-gray-900 placeholder:text-gray-400",
+        : "bg-white border-[#000000] text-gray-900 placeholder:text-gray-400",
     },
 
     /**

--- a/src/hooks/useThemeClasses.ts
+++ b/src/hooks/useThemeClasses.ts
@@ -56,7 +56,7 @@ export function useThemeClasses() {
      */
     border: {
       /** Default border color */
-      default: isDark ? "border-gray-700" : "border-gray-200",
+      default: isDark ? "border-gray-700" : "border-[#404040]",
       /** Subtle border */
       subtle: isDark ? "border-gray-600" : "border-gray-300",
       /** Strong/emphasis border */

--- a/src/index.css
+++ b/src/index.css
@@ -101,6 +101,11 @@ html {
   scroll-behavior: smooth;
 }
 
+/* Timeline marker animation - smooth transition when destroyed */
+.leaflet-interactive {
+  transition: r 1000ms ease-out, fill 1000ms ease-out, fill-opacity 1000ms ease-out;
+}
+
 /* Respect user preferences for reduced motion */
 @media (prefers-reduced-motion: reduce) {
   *,
@@ -116,5 +121,10 @@ html {
   button:hover,
   button:active {
     will-change: auto;
+  }
+
+  /* Disable marker transitions for reduced motion */
+  .leaflet-interactive {
+    transition: none !important;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -101,6 +101,11 @@ html {
   scroll-behavior: smooth;
 }
 
+/* Custom darker shadow for main components (2x darker than shadow-xl) */
+.shadow-2xl-dark {
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.5), 0 8px 10px -6px rgba(0, 0, 0, 0.5);
+}
+
 /* Timeline marker animation - smooth transition when destroyed */
 .leaflet-interactive {
   transition: r 1000ms ease-out, fill 1000ms ease-out, fill-opacity 1000ms ease-out;

--- a/src/styles/components.ts
+++ b/src/styles/components.ts
@@ -40,9 +40,9 @@ export const components = {
 
   // Tag/Chip styles (for removable filter tags)
   tag: {
-    base: "inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-full",
-    default: "bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium border border-gray-200 transition-colors duration-200",
-    removeButton: "ml-0.5 text-gray-500 hover:text-[#ed3039] transition-colors",  // Palestine flag red
+    base: "inline-flex items-center gap-0.5 px-1.5 py-0.5 text-xs rounded",
+    default: "bg-gray-500 hover:bg-gray-600 text-white font-medium border border-gray-600 transition-colors duration-200",
+    removeButton: "ml-0.5 text-gray-200 hover:text-[#ed3039] transition-colors text-sm font-bold leading-none",  // Palestine flag red
   },
 
   // Badge styles

--- a/src/styles/components.ts
+++ b/src/styles/components.ts
@@ -22,15 +22,15 @@ export const components = {
 
   // Form styles
   input: {
-    base: "px-3 py-2 border border-gray-200 rounded-lg text-sm text-gray-900 bg-white transition-all duration-200 placeholder:text-gray-400",
+    base: "px-3 py-2 border border-[#000000] rounded-lg text-sm text-gray-900 bg-white transition-all duration-200 placeholder:text-gray-400",
     focus: "focus:outline-none focus:ring-2 focus:ring-[#009639] focus:border-transparent",
     number: "w-20",
     date: "",
   },
 
   select: {
-    base: "w-full px-4 py-2 border border-[#d4d4d4] rounded-md text-gray-900 bg-white focus:ring-2 focus:ring-[#009639] focus:border-[#009639]",  // Palestine flag green focus
-    small: "px-2 py-2 border border-gray-300 rounded-md text-sm text-gray-900 bg-white focus:ring-2 focus:ring-[#009639] focus:border-[#009639]",
+    base: "w-full px-4 py-2 border border-[#000000] rounded-md text-gray-900 bg-white focus:ring-2 focus:ring-[#009639] focus:border-[#009639]",  // Palestine flag green focus
+    small: "px-2 py-2 border border-[#000000] rounded-md text-sm text-gray-900 bg-white focus:ring-2 focus:ring-[#009639] focus:border-[#009639]",
   },
 
   label: {

--- a/src/styles/components.ts
+++ b/src/styles/components.ts
@@ -13,11 +13,11 @@ export const components = {
 
   // Button styles
   button: {
-    base: "px-4 py-2 rounded-lg font-semibold transition-colors",
-    primary: "bg-[#009639] text-[#fefefe] hover:bg-[#007b2f]",        // Palestine flag green
-    secondary: "bg-[#f5f5f5] text-[#404040] hover:bg-[#e5e5e5]",      // Palestine grays
-    reset: "px-4 py-2 bg-[#ed3039] text-[#fefefe] rounded-md hover:bg-[#d4202a] transition-colors text-sm",  // Palestine flag red
-    toggle: "px-3 py-1.5 bg-gray-100 hover:bg-gray-200 border border-gray-300 rounded-md text-sm font-medium text-gray-700 transition-colors",
+    base: "px-4 py-2 rounded-lg font-semibold transition-colors border border-[#000000]",
+    primary: "bg-[#009639] text-[#fefefe] hover:bg-[#007b2f] border border-[#000000]",        // Palestine flag green
+    secondary: "bg-[#f5f5f5] text-[#404040] hover:bg-[#e5e5e5] border border-[#000000]",      // Palestine grays
+    reset: "px-4 py-2 bg-[#ed3039] text-[#fefefe] rounded-md hover:bg-[#d4202a] transition-colors text-sm border border-[#000000]",  // Palestine flag red
+    toggle: "px-3 py-1.5 bg-gray-100 hover:bg-gray-200 border border-[#000000] rounded-md text-sm font-medium text-gray-700 transition-colors",
   },
 
   // Form styles

--- a/src/styles/components.ts
+++ b/src/styles/components.ts
@@ -83,7 +83,7 @@ export const components = {
     base: "w-full text-sm text-left",
     header: "bg-[#000000] text-[#fefefe] sticky top-0 z-10",  // Palestine flag black and white
     th: "px-4 py-3 font-semibold",
-    row: "border-b border-[#e5e5e5] hover:bg-[#fafafa] cursor-pointer transition-all",
+    row: "border-b border-[#404040] hover:bg-[#fafafa] cursor-pointer transition-all",
     td: "px-4 py-3",
   },
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
         singleThread: true,
       },
     },
-    isolate: false,
+    isolate: true, // Changed to true to prevent mock interference between test files
     // Reduce transform overhead
     deps: {
       optimizer: {


### PR DESCRIPTION
## Summary
- Enhanced timeline with hover date labels and marker animations
- Improved visual consistency with darker shadows and unified borders
- Added filter UX improvements with disabled states and visual feedback
- Updated site type icons for better distinctiveness
- Refined component styling and spacing throughout

## Visual Enhancements
- **Timeline improvements**: Date labels appear on hover over event markers, markers animate (turn black and shrink) when timeline passes destruction date
- **Shadow depth**: All main components (table, timeline, maps, filter bar) now use 2x darker shadows for better depth perception
- **Border consistency**: All buttons and inputs now have black borders, map borders reduced to 2px for cleaner look
- **Table styling**: Site names 1 size larger, row borders changed to dark grey for better visibility
- **Component alignment**: Timeline bottom now aligns with table bottom

## UX Improvements
- **Disabled button states**: Reset button (timeline), Clear All and Apply Filters (modal) are now disabled/greyed when not applicable
- **Filter visual feedback**: Orange indicator badge shows when filters have unapplied changes
- **Date filter sync**: Timeline date filter now syncs with FilterBar destruction date filter
- **Dynamic filter defaults**: Year Built filter dynamically sets min/max based on current data

## Icon Updates
- Replaced site type icons with more distinct symbols for better differentiation
- Icons now use: 🕌 Mosque, ⛪ Church, 🏛️ Archaeological, 🏛️ Museum, 🏰 Historic Building

## Technical Details
- Added CSS transitions for 1-second marker animations (respects prefers-reduced-motion)
- Improved dark mode test isolation with proper DOM cleanup
- Added comprehensive tests for filter defaults and behavior
- Custom shadow-2xl-dark class for enhanced depth effect

## Testing
- ✅ All 237 tests passing
- ✅ Linting clean
- ✅ Visual verification in both light and dark modes
- ✅ Timeline animations working smoothly
- ✅ All disabled states functioning correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)