### PR TITLE
Fix: Enable mock API in production until Supabase configured

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -3,5 +3,6 @@
 # API Base URL (production backend server - update when deployed)
 VITE_API_URL=https://api.heritagetracker.com/api
 
-# Disable mock API in production (use real backend)
-VITE_USE_MOCK_API=false
+# Use mock API until Supabase is configured
+# TODO: Set to false once VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY are configured
+VITE_USE_MOCK_API=true


### PR DESCRIPTION
## Summary

Fixes production site error by enabling mock API until Supabase environment variables are configured.

## Problem

Production site was displaying error: **"Supabase not configured"**

**Root Cause:**
- `.env.production` had `VITE_USE_MOCK_API=false`
- No Supabase credentials configured (`VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`)
- Application attempted to use Supabase backend and failed

## Solution

Changed `.env.production` to use mock API temporarily:

```diff
- # Disable mock API in production (use real backend)
- VITE_USE_MOCK_API=false
+ # Use mock API until Supabase is configured
+ # TODO: Set to false once VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY are configured
+ VITE_USE_MOCK_API=true
```

## Impact

✅ **Production site now loads correctly**
- Uses mock data (44 heritage sites)
- Same behavior as development environment
- No breaking changes for users

## Next Steps

When ready to use Supabase backend:

1. Configure production environment variables:
   - `VITE_SUPABASE_URL` - Your Supabase project URL
   - `VITE_SUPABASE_ANON_KEY` - Your Supabase anonymous key

2. Update `.env.production`:
   ```
   VITE_USE_MOCK_API=false
   ```

3. Redeploy

## Testing

- ✅ Production build successful
- ✅ Mock API provides data correctly
- ✅ No console errors

## Files Changed

- `.env.production` - Enable mock API with TODO comment

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>