### PR TITLE
fix: update deploy workflow bundle size limit to 5MB

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Check bundle size limit
         run: |
           BUNDLE_SIZE=$(du -sb dist/ | awk '{print $1}')
-          MAX_SIZE=$((1536 * 1024))  # 1.5MB limit (increased for logo assets)
+          MAX_SIZE=$((5120 * 1024))  # 5MB limit (includes 2.9MB satellite imagery + 1.4MB assets)
           if [ $BUNDLE_SIZE -gt $MAX_SIZE ]; then
             echo "❌ Bundle size ($BUNDLE_SIZE bytes) exceeds limit ($MAX_SIZE bytes)"
             exit 1


### PR DESCRIPTION
## Summary
Updates the deployment workflow bundle size limit from 1.5MB to 5MB to match the PR checks workflow and accommodate satellite imagery in production deployments.

## Changes
- Updated `.github/workflows/deploy.yml` bundle size limit to 5MB

## Justification
The bundle breakdown is:
- **Satellite imagery:** 2.9MB (138 images for 69 heritage sites)
- **Application assets:** 1.4MB (JS, CSS, logo)
- **Total:** 4.3MB with 16% buffer for future growth

This matches the fix applied to `pr-checks.yml` in #[previous PR number]. The satellite imagery is essential for the comparison mode feature and represents reasonable compression (~21KB per image).

## Test Plan
- [x] Local production build succeeds (4.3MB)
- [ ] Deployment workflow passes with new limit
- [ ] Application deploys successfully to GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)