### PR TITLE
fix: enable image loading in production with BASE_URL path handling

### DIFF
--- a/src/components/SiteDetail/SiteImage.tsx
+++ b/src/components/SiteDetail/SiteImage.tsx
@@ -14,12 +14,25 @@ interface SiteImageProps {
  * Displays image with proper credit and licensing information below
  */
 export function SiteImage({ image, alt, label, className }: SiteImageProps) {
+  // Handle both absolute URLs and relative paths
+  const getImageUrl = (url: string) => {
+    // If it's an absolute URL (http/https), return as-is
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+      return url;
+    }
+    // For relative paths, prepend the base URL
+    const baseUrl = import.meta.env.BASE_URL || '/';
+    // Remove leading slash from url if present to avoid double slashes
+    const cleanUrl = url.startsWith('/') ? url.slice(1) : url;
+    return `${baseUrl}${cleanUrl}`;
+  };
+
   return (
     <div className={cn("space-y-2", className)}>
       {/* Image */}
       <div className="relative">
         <img
-          src={image.url}
+          src={getImageUrl(image.url)}
           alt={alt}
           className="w-full h-64 object-cover rounded-lg shadow-md"
           onError={(e) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
         ]
       },
       workbox: {
-        globPatterns: ['**/*.{js,css,html,ico,png,svg,json}'],
+        globPatterns: ['**/*.{js,css,html,ico,png,svg,json,jpg,jpeg}'],
         runtimeCaching: [
           {
             urlPattern: /^https:\/\/tile\.openstreetmap\.org\/.*/i,


### PR DESCRIPTION
## Summary
Fixes satellite imagery not displaying in production deployments by implementing BASE_URL-aware image path resolution.

## Problem
All 138 satellite images showed "image unavailable" in production (GitHub Pages) while working correctly in development:
- Image paths in mockSites.ts: `/images/sites/...`
- Production base path: `/HeritageTracker/`
- Required paths: `/HeritageTracker/images/sites/...`

## Solution

### 1. PWA Service Worker Configuration
**File:** `vite.config.ts`
```typescript
globPatterns: ['**/*.{js,css,html,ico,png,svg,json,jpg,jpeg}']
```
- Added `jpg,jpeg` to workbox glob patterns
- Ensures 138 satellite images are precached (4MB total)
- Enables offline image access via service worker

### 2. Dynamic Image Path Resolution
**File:** `src/components/SiteDetail/SiteImage.tsx`
```typescript
const getImageUrl = (url: string) => {
  if (url.startsWith('http://') || url.startsWith('https://')) {
    return url; // Absolute URLs unchanged
  }
  const baseUrl = import.meta.env.BASE_URL || '/';
  const cleanUrl = url.startsWith('/') ? url.slice(1) : url;
  return `${baseUrl}${cleanUrl}`;
};
```
- Handles both absolute URLs and relative paths
- Production: `/images/...` → `/HeritageTracker/images/...`
- Development: `/images/...` → `/images/...`

## Testing
- ✅ Production build succeeds (4.3MB with images)
- ✅ PWA precaches 159 entries (138 images + assets)
- ✅ Local preview server confirms image loading at `/HeritageTracker/` base path
- ✅ All tests pass
- ✅ Bundle size within 5MB limit

## Impact
- Fixes critical production bug affecting all site detail views
- Enables offline image viewing via PWA
- No breaking changes to development workflow

## Related
- Follows deployment workflow fix in #60 (bundle size limit)
- Completes satellite imagery feature from recent commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)