### PR TITLE
feat: move map settings to individual maps on Timeline page

### DIFF
--- a/src/components/Map/ComparisonMapView.tsx
+++ b/src/components/Map/ComparisonMapView.tsx
@@ -12,6 +12,20 @@ interface ComparisonMapViewProps {
   /** Later/after imagery configuration */
   after: WaybackImagery;
   onSiteClick?: (site: Site) => void;
+  /** Before map settings */
+  beforeMapSettings?: {
+    zoomToSite: boolean;
+    onZoomToSiteChange: (enabled: boolean) => void;
+    showMarkers: boolean;
+    onShowMarkersChange: (enabled: boolean) => void;
+  };
+  /** After map settings */
+  afterMapSettings?: {
+    zoomToSite: boolean;
+    onZoomToSiteChange: (enabled: boolean) => void;
+    showMarkers: boolean;
+    onShowMarkersChange: (enabled: boolean) => void;
+  };
 }
 
 /**
@@ -35,6 +49,8 @@ export function ComparisonMapView({
   before,
   after,
   onSiteClick,
+  beforeMapSettings,
+  afterMapSettings,
 }: ComparisonMapViewProps) {
   const t = useThemeClasses();
 
@@ -57,6 +73,10 @@ export function ComparisonMapView({
             customMaxZoom={before.maxZoom}
             onSiteClick={onSiteClick}
             comparisonModeActive={true}
+            zoomToSiteOverride={beforeMapSettings?.zoomToSite}
+            onZoomToSiteChange={beforeMapSettings?.onZoomToSiteChange}
+            mapMarkersOverride={beforeMapSettings?.showMarkers}
+            onMapMarkersChange={beforeMapSettings?.onShowMarkersChange}
           />
         </div>
 
@@ -75,6 +95,10 @@ export function ComparisonMapView({
             customMaxZoom={after.maxZoom}
             onSiteClick={onSiteClick}
             comparisonModeActive={true}
+            zoomToSiteOverride={afterMapSettings?.zoomToSite}
+            onZoomToSiteChange={afterMapSettings?.onZoomToSiteChange}
+            mapMarkersOverride={afterMapSettings?.showMarkers}
+            onMapMarkersChange={afterMapSettings?.onShowMarkersChange}
           />
         </div>
       </div>

--- a/src/components/Map/SiteDetailView.tsx
+++ b/src/components/Map/SiteDetailView.tsx
@@ -28,6 +28,14 @@ interface SiteDetailViewProps {
   onSiteClick?: (site: Site) => void;
   // Optional flag to indicate if comparison mode is active (disables adaptive zoom)
   comparisonModeActive?: boolean;
+  // Optional override for zoom to site setting (used in comparison mode for independent control)
+  zoomToSiteOverride?: boolean;
+  // Optional callback for zoom to site change (used in comparison mode for independent control)
+  onZoomToSiteChange?: (enabled: boolean) => void;
+  // Optional override for map markers visibility (used in comparison mode for independent control)
+  mapMarkersOverride?: boolean;
+  // Optional callback for map markers change (used in comparison mode for independent control)
+  onMapMarkersChange?: (enabled: boolean) => void;
 }
 
 /**
@@ -45,11 +53,21 @@ export function SiteDetailView({
   dateLabel,
   onSiteClick,
   comparisonModeActive = false,
+  zoomToSiteOverride,
+  onZoomToSiteChange,
+  mapMarkersOverride,
+  onMapMarkersChange,
 }: SiteDetailViewProps) {
   // Get animation context for timeline sync and zoom toggle
-  const { currentTimestamp, syncActive, zoomToSiteEnabled, mapMarkersVisible, setZoomToSiteEnabled, setMapMarkersVisible } = useAnimation();
+  const { currentTimestamp, syncActive, zoomToSiteEnabled: contextZoomToSite, mapMarkersVisible: contextMapMarkers, setZoomToSiteEnabled: contextSetZoomToSite, setMapMarkersVisible: contextSetMapMarkers } = useAnimation();
   const translate = useTranslation();
   const t = useThemeClasses();
+
+  // Use override values if provided (comparison mode), otherwise use context values
+  const zoomToSiteEnabled = zoomToSiteOverride !== undefined ? zoomToSiteOverride : contextZoomToSite;
+  const mapMarkersVisible = mapMarkersOverride !== undefined ? mapMarkersOverride : contextMapMarkers;
+  const setZoomToSiteEnabled = onZoomToSiteChange || contextSetZoomToSite;
+  const setMapMarkersVisible = onMapMarkersChange || contextSetMapMarkers;
 
   // Time period state for historical imagery
   const [selectedPeriod, setSelectedPeriod] = useState<TimePeriod>("CURRENT");
@@ -186,8 +204,8 @@ export function SiteDetailView({
         )}
       </MapContainer>
 
-      {/* Map settings - only show on Dashboard (not on Timeline page with custom tiles) */}
-      {!customTileUrl && (
+      {/* Map settings - show on Dashboard (no custom tiles) or when override props provided (comparison/timeline mode) */}
+      {(!customTileUrl || (onZoomToSiteChange !== undefined && onMapMarkersChange !== undefined)) && (
         <div className={`absolute bottom-2 left-2 z-[1000] ${t.bg.panel} backdrop-blur-sm border ${t.border.primary} rounded px-2 py-1.5 shadow-md`}>
           <div className="flex flex-col gap-1 text-xs">
             <label className="flex items-center gap-1.5 cursor-pointer hover:opacity-80 transition-opacity">

--- a/src/pages/Timeline.tsx
+++ b/src/pages/Timeline.tsx
@@ -88,6 +88,16 @@ export function Timeline() {
     DEFAULT_COMPARISON_INTERVAL
   );
 
+  // Map settings for before/after maps (independent controls)
+  const [beforeMapZoomToSite, setBeforeMapZoomToSite] = useState(true);
+  const [beforeMapShowMarkers, setBeforeMapShowMarkers] = useState(false);
+  const [afterMapZoomToSite, setAfterMapZoomToSite] = useState(true);
+  const [afterMapShowMarkers, setAfterMapShowMarkers] = useState(false);
+
+  // Map settings for single map mode
+  const [singleMapZoomToSite, setSingleMapZoomToSite] = useState(true);
+  const [singleMapShowMarkers, setSingleMapShowMarkers] = useState(false);
+
   // Modal states for footer and help
   const [isHelpOpen, setIsHelpOpen] = useState(false);
 
@@ -306,6 +316,18 @@ export function Timeline() {
                       dateLabel: currentRelease?.releaseDate,
                     }}
                     onSiteClick={setSelectedSite}
+                    beforeMapSettings={{
+                      zoomToSite: beforeMapZoomToSite,
+                      onZoomToSiteChange: setBeforeMapZoomToSite,
+                      showMarkers: beforeMapShowMarkers,
+                      onShowMarkersChange: setBeforeMapShowMarkers,
+                    }}
+                    afterMapSettings={{
+                      zoomToSite: afterMapZoomToSite,
+                      onZoomToSiteChange: setAfterMapZoomToSite,
+                      showMarkers: afterMapShowMarkers,
+                      onShowMarkersChange: setAfterMapShowMarkers,
+                    }}
                   />
                 ) : (
                   <SiteDetailView
@@ -316,6 +338,10 @@ export function Timeline() {
                     dateLabel={currentRelease?.releaseDate}
                     onSiteClick={setSelectedSite}
                     comparisonModeActive={false}
+                    zoomToSiteOverride={singleMapZoomToSite}
+                    onZoomToSiteChange={setSingleMapZoomToSite}
+                    mapMarkersOverride={singleMapShowMarkers}
+                    onMapMarkersChange={setSingleMapShowMarkers}
                   />
                 )}
               </Suspense>
@@ -351,6 +377,7 @@ export function Timeline() {
                     syncMapOnDotClick,
                     showNavigation: true, // Show Previous/Next buttons
                     hidePlayControls: true, // Hide Play/Pause/Speed controls on Advanced Timeline page
+                    hideMapSettings: true, // Hide Zoom to Site and Show Map Markers (moved to maps above)
                     onReset: handleWaybackReset, // Reset wayback sliders to initial positions
                   }}
                 />


### PR DESCRIPTION
## Summary

- Moved "Zoom to Site" and "Show Map Markers" toggles from the global AdvancedTimeline component to individual map instances on the Timeline page
- Each map (before/after in comparison mode, or single map) now has independent controls for zoom and marker visibility
- Improves UX by allowing users to configure each map separately when comparing satellite imagery

## Changes

### Components Modified

- **[ComparisonMapView.tsx](src/components/Map/ComparisonMapView.tsx)**: Added `beforeMapSettings` and `afterMapSettings` props to pass independent controls to each SiteDetailView instance
- **[SiteDetailView.tsx](src/components/Map/SiteDetailView.tsx)**: Added override props (`zoomToSiteOverride`, `onZoomToSiteChange`, `mapMarkersOverride`, `onMapMarkersChange`) to support independent settings in comparison mode
- **[Timeline.tsx](src/pages/Timeline.tsx)**: Added local state for map settings (6 new state variables) and wired them to the appropriate map instances

### Technical Details

- Before/after maps in comparison mode each have their own settings state
- Single map mode also has independent settings state
- Map settings UI now appears on individual maps when override props are provided
- Settings visibility logic updated: shows on Dashboard (no custom tiles) OR when override props provided
- All existing functionality preserved, only adds independent control capability

## Test Plan

- [x] Verify map settings toggles appear on each map in comparison mode
- [x] Test that before/after maps can have different zoom/marker settings
- [x] Verify single map mode settings work independently
- [x] Check that Dashboard page map settings still work (no regression)
- [x] Test state persistence during mode switching (comparison ↔ single)
- [x] Verify responsive behavior on mobile/tablet

🤖 Generated with [Claude Code](https://claude.com/claude-code)