### PR TITLE
feat: hide About page from navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,10 +9,16 @@ import { ErrorBoundary } from "./components/ErrorBoundary/ErrorBoundary";
 import { ScrollToTop } from "./components/ScrollToTop";
 import { DashboardPage } from "./pages/DashboardPage";
 import { Timeline } from "./pages/Timeline";
-import { AboutPage } from "./pages/AboutPage";
 import { DonatePage } from "./pages/DonatePage";
 import { DataPage } from "./pages/DataPage";
-import { OrganizationsPage, ResearchPage, MediaPage, EducationPage, LegalPage, TrackersPage } from "./pages/resources";
+import {
+  OrganizationsPage,
+  ResearchPage,
+  MediaPage,
+  EducationPage,
+  LegalPage,
+  TrackersPage,
+} from "./pages/resources";
 import { BREAKPOINTS } from "./constants/layout";
 
 /**
@@ -25,7 +31,6 @@ function AppRouter({ isMobile }: { isMobile: boolean }) {
       <Route path="/" element={isMobile ? <DataPage /> : <DashboardPage />} />
       <Route path="/data" element={<DataPage />} />
       <Route path="/timeline" element={<Timeline />} />
-      <Route path="/about" element={<AboutPage />} />
 
       {/* Legacy donate route - redirect to resources/donate */}
       <Route path="/donate" element={<DonatePage />} />
@@ -51,7 +56,7 @@ export function App() {
   // Check if we're on mobile - initialize immediately from window.innerWidth
   const [isMobile, setIsMobile] = useState(() => {
     // Check during initial render (works in browser, defaults to false in SSR)
-    return typeof window !== 'undefined' && window.innerWidth < BREAKPOINTS.MOBILE;
+    return typeof window !== "undefined" && window.innerWidth < BREAKPOINTS.MOBILE;
   });
 
   useEffect(() => {
@@ -61,14 +66,14 @@ export function App() {
 
     // Recheck on mount (in case window was resized before mount)
     checkMobile();
-    window.addEventListener('resize', checkMobile);
-    return () => window.removeEventListener('resize', checkMobile);
+    window.addEventListener("resize", checkMobile);
+    return () => window.removeEventListener("resize", checkMobile);
   }, []);
 
   // Determine basename - should match Vite's base config
   // Production (GitHub Pages): /HeritageTracker/
   // Development/E2E: /
-  const basename = import.meta.env.PROD ? '/HeritageTracker' : '';
+  const basename = import.meta.env.PROD ? "/HeritageTracker" : "";
 
   return (
     <BrowserRouter basename={basename}>

--- a/src/components/Layout/AppFooter.tsx
+++ b/src/components/Layout/AppFooter.tsx
@@ -69,14 +69,6 @@ export function AppFooter({ isMobile }: AppFooterProps) {
                 {translate("footer.stats")}
               </Link>
               {" • "}
-              <Link
-                to="/about"
-                className="underline hover:text-[#fefefe]/80 transition-colors"
-                aria-label={translate("aria.aboutHeritageTracker")}
-              >
-                {translate("footer.about")}
-              </Link>
-              {" • "}
               <a
                 href="https://github.com/yupitsleen/HeritageTracker"
                 target="_blank"

--- a/src/components/Layout/AppHeader.test.tsx
+++ b/src/components/Layout/AppHeader.test.tsx
@@ -55,7 +55,7 @@ describe("AppHeader", () => {
       expect(screen.getByRole("button", { name: /dashboard/i })).toBeInTheDocument();
       expect(screen.getByRole("button", { name: /data/i })).toBeInTheDocument();
       expect(screen.getByRole("button", { name: /timeline/i })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: /about/i })).toBeInTheDocument();
+      // About page has been hidden from navigation
     });
 
     it("renders theme toggle button", () => {
@@ -121,7 +121,7 @@ describe("AppHeader", () => {
       // All nav items should be present (except Dashboard which is conditionally hidden on mobile)
       expect(screen.getAllByRole("button", { name: /data/i })).toHaveLength(2); // Desktop + Mobile
       expect(screen.getAllByRole("button", { name: /timeline/i })).toHaveLength(2);
-      expect(screen.getAllByRole("button", { name: /about/i })).toHaveLength(2);
+      // About page has been hidden from navigation
     });
 
     it("mobile menu includes theme toggle", () => {
@@ -147,9 +147,7 @@ describe("AppHeader", () => {
 
       // Click a nav item (Data is always present in mobile menu)
       const dataButtons = screen.getAllByRole("button", { name: /data/i });
-      const mobileDataButton = dataButtons.find(button =>
-        button.classList.contains("w-full")
-      );
+      const mobileDataButton = dataButtons.find((button) => button.classList.contains("w-full"));
 
       if (mobileDataButton) {
         fireEvent.click(mobileDataButton);
@@ -267,9 +265,7 @@ describe("AppHeader", () => {
 
       // Data button should have active styling (ring-2 class)
       const dataButtons = container.querySelectorAll('[aria-label*="Data"]');
-      const activeButton = Array.from(dataButtons).find(btn =>
-        btn.className.includes("ring-2")
-      );
+      const activeButton = Array.from(dataButtons).find((btn) => btn.className.includes("ring-2"));
 
       expect(activeButton).toBeInTheDocument();
     });

--- a/src/components/Layout/NavigationLinks.tsx
+++ b/src/components/Layout/NavigationLinks.tsx
@@ -6,7 +6,7 @@ import type { TranslationKey } from "../../types/i18n";
 interface NavigationItem {
   path: string;
   translationKey: TranslationKey;
-  variant: 'primary' | 'secondary' | 'danger';
+  variant: "primary" | "secondary" | "danger";
   hideOnMobile?: boolean;
 }
 
@@ -14,14 +14,13 @@ interface NavigationLinksProps {
   activePage: string | null;
   isMobileSize: boolean;
   onNavigate: (path: string) => void;
-  layout: 'desktop' | 'mobile';
+  layout: "desktop" | "mobile";
 }
 
 const NAV_ITEMS: NavigationItem[] = [
-  { path: '/', translationKey: 'header.dashboard', variant: 'primary', hideOnMobile: true },
-  { path: '/data', translationKey: 'header.data', variant: 'primary' },
-  { path: '/timeline', translationKey: 'header.timeline', variant: 'secondary' },
-  { path: '/about', translationKey: 'header.about', variant: 'primary' },
+  { path: "/", translationKey: "header.dashboard", variant: "primary", hideOnMobile: true },
+  { path: "/data", translationKey: "header.data", variant: "primary" },
+  { path: "/timeline", translationKey: "header.timeline", variant: "secondary" },
 ];
 
 /**
@@ -36,37 +35,42 @@ const NAV_ITEMS: NavigationItem[] = [
  * @param onNavigate - Callback when navigation button is clicked
  * @param layout - 'desktop' or 'mobile' layout variant
  */
-export function NavigationLinks({ activePage, isMobileSize, onNavigate, layout }: NavigationLinksProps) {
+export function NavigationLinks({
+  activePage,
+  isMobileSize,
+  onNavigate,
+  layout,
+}: NavigationLinksProps) {
   const t = useTranslation();
 
   // Desktop: small buttons, no full width
   // Mobile: larger buttons, full width, left-aligned
-  const size = layout === 'mobile' ? 'sm' : 'xs';
-  const baseClassName = layout === 'mobile' ? 'w-full justify-start' : '';
+  const size = layout === "mobile" ? "sm" : "xs";
+  const baseClassName = layout === "mobile" ? "w-full justify-start" : "";
 
   return (
     <>
       {NAV_ITEMS.map(({ path, translationKey, variant, hideOnMobile }) => {
         // Skip Dashboard on mobile devices (< 1024px)
-        if (hideOnMobile && layout === 'mobile' && isMobileSize) {
+        if (hideOnMobile && layout === "mobile" && isMobileSize) {
           return null;
         }
 
         // Determine if this nav item is active
-        const pageKey = path === '/' ? 'dashboard' : path.substring(1); // '/data' -> 'data'
+        const pageKey = path === "/" ? "dashboard" : path.substring(1); // '/data' -> 'data'
         const isActive = activePage === pageKey;
 
         return (
           <Button
             key={path}
             onClick={() => onNavigate(path)}
-            variant={isActive ? variant : 'ghost'}
+            variant={isActive ? variant : "ghost"}
             size={size}
             lightText
             aria-label={t(translationKey)}
-            className={`${baseClassName} ${
-              isActive ? 'ring-2 ring-white/50' : ''
-            } ${layout === 'desktop' && isActive ? 'border' : layout === 'desktop' ? 'border-0' : ''}`}
+            className={`${baseClassName} ${isActive ? "ring-2 ring-white/50" : ""} ${
+              layout === "desktop" && isActive ? "border" : layout === "desktop" ? "border-0" : ""
+            }`}
           >
             {t(translationKey)}
           </Button>
@@ -74,11 +78,7 @@ export function NavigationLinks({ activePage, isMobileSize, onNavigate, layout }
       })}
 
       {/* Resources Dropdown */}
-      <ResourcesDropdown
-        activePage={activePage}
-        onNavigate={onNavigate}
-        layout={layout}
-      />
+      <ResourcesDropdown activePage={activePage} onNavigate={onNavigate} layout={layout} />
     </>
   );
 }


### PR DESCRIPTION
Hide the About page from the website navigation and footer while keeping all files intact for future use.

Changes:
- Removed /about route from App.tsx
- Removed About navigation link from header and footer
- Updated tests to reflect navigation changes

Verification:
- All 1,457 unit tests passing
- Linter passes with zero warnings
- Production build successful

The AboutPage component and files remain in the codebase for potential future use or restoration.